### PR TITLE
removed unnecessary 'use client;' flags, added e2e mobile test

### DIFF
--- a/app/_components/footer/Footer.tsx
+++ b/app/_components/footer/Footer.tsx
@@ -1,5 +1,3 @@
-'use client';
-
 import { Box, useColorMode } from '@chakra-ui/react';
 
 const Footer = () => {

--- a/app/_components/navbar/Navbar.tsx
+++ b/app/_components/navbar/Navbar.tsx
@@ -1,5 +1,3 @@
-'use client';
-
 import { Flex, IconButton, useColorMode, Text, Image } from '@chakra-ui/react';
 import { MoonIcon, SunIcon } from '@chakra-ui/icons';
 

--- a/app/_config/theme/fonts.ts
+++ b/app/_config/theme/fonts.ts
@@ -1,5 +1,3 @@
-'use client';
-
 import localFont from 'next/font/local';
 import { Orbitron, Rubik } from 'next/font/google';
 

--- a/app/_config/theme/index.ts
+++ b/app/_config/theme/index.ts
@@ -1,5 +1,3 @@
-'use client';
-
 import { extendTheme } from '@chakra-ui/react';
 import { rubik, orbitron } from './fonts';
 

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -54,24 +54,13 @@ const config: PlaywrightTestConfig = {
         ...devices['Desktop Firefox'],
       },
     },
-    // {
-    //   name: 'Desktop Safari',
-    //   use: {
-    //     ...devices['Desktop Safari'],
-    //   },
-    // },
     // Test against mobile viewports.
-    // NOTE: aslink87 - I don't think we need to test against mobile viewports
-    // {
-    //   name: 'Mobile Chrome',
-    //   use: {
-    //     ...devices['Pixel 5'],
-    //   },
-    // },
-    // {
-    //   name: 'Mobile Safari',
-    //   use: devices['iPhone 12'],
-    // },
+    {
+      name: 'Mobile Chrome',
+      use: {
+        ...devices['Pixel 5'],
+      },
+    },
   ],
 };
 export default config;


### PR DESCRIPTION
just knocking out some minor fixes.

> To use Chakra UI in server components, you need to convert them into client-side component by adding a 'use client'; at the top of your file.

For these components that are being imported into pages that already have a 'use client;' flag, the components don't need it as well for Chakra functionality.