### PR TITLE
Automate screenshots for responsive testing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@
 # testing
 /coverage
 /tests/playwright/test-results
+/tests/playwright/screenshots
 
 # next.js
 /.next/

--- a/README.md
+++ b/README.md
@@ -46,6 +46,13 @@ yarn lint
 yarn test
 ```
 
+### Take Screenshots
+If you are making changes that impact the UI, ensure to test the change on different view ports. Run the following to auto capture screenshots when tests run. Note that this only runs when you run this command locally.
+
+```bash
+yarn capture-screenshots
+```
+
 ## 🐳 Using Docker and Makefile
 
 Enter the values in the `.env` for localhost and `.env.development.sample`, `.env.production.sample` for respective environments. Only change `docker` folder files if you are involved in managing deployment to these stages.

--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
     "analyze:browser": "cross-env BUNDLE_ANALYZE=browser next build",
     "test": "yarn test:e2e && yarn test:unit",
     "test:e2e": "playwright test",
-    "test:unit": "jest"
+    "test:unit": "jest",
+    "capture-screenshots": "RUN_SCREENSHOT_TEST=true yarn test"
   },
   "dependencies": {
     "@chakra-ui/icons": "^2.0.19",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -43,20 +43,20 @@ const config: PlaywrightTestConfig = {
 
   projects: [
     {
-      name: 'Desktop Chrome',
+      name: 'Desktop-Chrome',
       use: {
         ...devices['Desktop Chrome'],
       },
     },
     {
-      name: 'Desktop Firefox',
+      name: 'Desktop-Firefox',
       use: {
         ...devices['Desktop Firefox'],
       },
     },
     // Test against mobile viewports.
     {
-      name: 'Mobile Chrome',
+      name: 'Mobile-Chrome',
       use: {
         ...devices['Pixel 5'],
       },

--- a/tests/playwright/capture-screenshots.test.ts
+++ b/tests/playwright/capture-screenshots.test.ts
@@ -1,0 +1,41 @@
+import { test, expect } from '@playwright/test';
+
+interface ScreenSize {
+  width: number;
+  height: number;
+}
+
+const screenSizes: ScreenSize[] = [
+  { width: 480, height: 640 },
+  { width: 768, height: 1024 },
+  { width: 1280, height: 1024 },
+  // Add more screen sizes as needed
+];
+
+const { RUN_SCREENSHOT_TEST } = process.env;
+// Change to the project you want to take screenshots using - check playwright.config.ts
+const projectName = 'Desktop-Chrome';
+
+if (RUN_SCREENSHOT_TEST === 'true') {
+  test.describe('Capture screenshots for different screen sizes', () => {
+    test(projectName, async ({ page }, testInfo) => {
+      const { name } = testInfo.project;
+      if (name === projectName) {
+        await page.goto('/');
+
+        await expect(page.getByRole('tabpanel', { name: 'Discover' })).toBeVisible();
+
+        // Capture screenshots for each screen size
+        for (const size of screenSizes) {
+          await page.setViewportSize(size);
+          await page.screenshot({
+            path: `./tests/playwright/screenshots/screenshot-${projectName}-${size.width}x${size.height}.png`,
+          });
+
+          console.log(`Screenshot captured for ${projectName} in ${size.width}x${size.height}`);
+        }
+    }
+  });
+});
+}
+


### PR DESCRIPTION
- [x] Enable developers to take screenshots locally on-demand
- [x] Create screenshots for common view ports
- [x] Only run this on-demand and for one browser base 