### PR TITLE
Auto screenshot now captures both color modes, eslint fixes

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -23,6 +23,9 @@
         "named": "never",
         "anonymous": "never"
       }
-    ]
+    ],
+    "import/no-extraneous-dependencies": ["error", {
+      "devDependencies": ["next.config.js", "jest.setup.js", "**/*.test.tsx", "**/*.test.ts"]
+    }]
   }
 }

--- a/next.config.js
+++ b/next.config.js
@@ -1,3 +1,7 @@
+const withBundleAnalyzer = require('@next/bundle-analyzer')({
+  enabled: process.env.ANALYZE === 'true',
+});
+
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   output: 'standalone',
@@ -6,10 +10,5 @@ const nextConfig = {
     domains: ['edpn.com'],
   },
 };
-
-// eslint-disable-next-line import/no-extraneous-dependencies -- only used in dev aslink87
-const withBundleAnalyzer = require('@next/bundle-analyzer')({
-  enabled: process.env.ANALYZE === 'true',
-});
 
 module.exports = withBundleAnalyzer(nextConfig);

--- a/tests/playwright/capture-screenshots.test.ts
+++ b/tests/playwright/capture-screenshots.test.ts
@@ -1,4 +1,4 @@
-import { test, expect } from '@playwright/test';
+import { test } from '@playwright/test';
 
 interface ScreenSize {
   width: number;
@@ -6,9 +6,10 @@ interface ScreenSize {
 }
 
 const screenSizes: ScreenSize[] = [
-  { width: 480, height: 640 },
+  { width: 480, height: 720 },
   { width: 768, height: 1024 },
   { width: 1280, height: 1024 },
+  { width: 1920, height: 1080 },
   // Add more screen sizes as needed
 ];
 
@@ -22,20 +23,25 @@ if (RUN_SCREENSHOT_TEST === 'true') {
       const { name } = testInfo.project;
       if (name === projectName) {
         await page.goto('/');
-
-        await expect(page.getByRole('tabpanel', { name: 'Discover' })).toBeVisible();
-
         // Capture screenshots for each screen size
-        for (const size of screenSizes) {
+        await screenSizes.reduce(async (promise, size) => {
+          await promise;
           await page.setViewportSize(size);
           await page.screenshot({
-            path: `./tests/playwright/screenshots/screenshot-${projectName}-${size.width}x${size.height}.png`,
+            path: `./tests/playwright/screenshots/screenshot-${projectName}-${size.width}x${size.height}-dark.png`,
           });
-
-          console.log(`Screenshot captured for ${projectName} in ${size.width}x${size.height}`);
-        }
-    }
+          // Toggle color mode
+          await page.click('button[aria-label="Toggle Dark Switch"]');
+          await page.screenshot({
+            path: `./tests/playwright/screenshots/screenshot-${projectName}-${size.width}x${size.height}-light.png`,
+          });
+          // Toggle color mode back to original
+          await page.click('button[aria-label="Toggle Dark Switch"]');
+          console.log(
+            `Screenshots captured for ${projectName} in ${size.width}x${size.height}`,
+          );
+        }, Promise.resolve());
+      }
+    });
   });
-});
 }
-


### PR DESCRIPTION
Expands on the [screenshot implementation](https://github.com/ed-pilots-network/frontend/issues/39) and adds color mode switch to take shots for both color modes