### PR TITLE
[Discarded] Setup proxy to call staging server with client & server side. Updates playground with documentation

### DIFF
--- a/.env
+++ b/.env
@@ -1,2 +1,3 @@
 NEXT_PUBLIC_STAGE=localhost
-NEXT_PUBLIC_API_URL=http://localhost:3001
+NEXT_PUBLIC_MOCK_API_URL=http://localhost:3001
+NEXT_PUBLIC_STAGING_API_URL=http://morris.edpn.io:8080

--- a/.env.development.sample
+++ b/.env.development.sample
@@ -1,2 +1,3 @@
 NEXT_PUBLIC_STAGE=development
-NEXT_PUBLIC_API_URL=https://api-development.com
+NEXT_PUBLIC_MOCK_API_URL=http://localhost:3001
+NEXT_PUBLIC_STAGING_API_URL=http://xxxx.edpn.io:8080

--- a/.env.production.sample
+++ b/.env.production.sample
@@ -1,2 +1,3 @@
 NEXT_PUBLIC_STAGE=production
-NEXT_PUBLIC_API_URL=https://api-production.com
+NEXT_PUBLIC_MOCK_API_URL=https://api-production.com
+NEXT_PUBLIC_STAGING_API_URL=http://api-staging.com

--- a/app/_components/navbar/Navbar.tsx
+++ b/app/_components/navbar/Navbar.tsx
@@ -1,5 +1,15 @@
-import { Flex, IconButton, Text, Image, Hide } from '@chakra-ui/react';
+import {
+  Flex,
+  IconButton,
+  Text,
+  Image,
+  Hide,
+  Badge,
+  Menu,
+  MenuButton,
+} from '@chakra-ui/react';
 import { MoonIcon, SunIcon } from '@chakra-ui/icons';
+import { MdCode } from 'react-icons/md';
 
 import { rift } from '@/app/_config/theme/fonts';
 import useColorMode from '@/app/_hooks/useColorMode';
@@ -39,15 +49,22 @@ const Navbar = () => {
       </Flex>
       <Flex justifyContent="space-between" alignItems="center">
         <Hide below="md">
-          <Text
-            ml={2}
+          <Badge
+            margin={2}
             px={2}
             fontSize="md"
-            color={selectColor(isDark, 'textLight')}
+            colorScheme={isDark ? 'orange' : 'gray'}
           >
-            Server: {process.env.NEXT_PUBLIC_STAGE}
-          </Text>
+            {process.env.NEXT_PUBLIC_STAGE}
+          </Badge>
         </Hide>
+        {process.env.NEXT_PUBLIC_STAGE === 'localhost' && (
+          <Menu>
+            <Link href="/playground">
+              <MenuButton as={IconButton} icon={<MdCode />} size="sm" m={2} />
+            </Link>
+          </Menu>
+        )}
         <IconButton
           aria-label="Toggle Dark Switch"
           icon={isDark ? <SunIcon /> : <MoonIcon />}

--- a/app/_components/navbar/navbar.test.tsx
+++ b/app/_components/navbar/navbar.test.tsx
@@ -18,7 +18,7 @@ test('renders the navbar with logo and toggle switch', () => {
   expect(logoText).toHaveStyle({ fontSize: '2xl' });
 
   // Server Stage
-  const serverStage = screen.getByText('Server: test-stage');
+  const serverStage = screen.getByText('test-stage');
   expect(serverStage).toBeInTheDocument();
 
   // Toggle switch

--- a/app/_types/commodity.ts
+++ b/app/_types/commodity.ts
@@ -1,0 +1,6 @@
+export interface ICommodity {
+  commodityName: string;
+  displayName: string;
+  type: string;
+  isRare: boolean;
+}

--- a/app/_types/index.ts
+++ b/app/_types/index.ts
@@ -1,0 +1,2 @@
+export type { ICommodity } from './commodity';
+export type { IPost } from './post';

--- a/app/_types/post.ts
+++ b/app/_types/post.ts
@@ -1,0 +1,5 @@
+export interface IPost {
+  id: number;
+  title: string;
+  author: string;
+}

--- a/app/playground/_api/index.tsx
+++ b/app/playground/_api/index.tsx
@@ -1,0 +1,45 @@
+import { ICommodity, IPost } from '../../_types';
+
+export const getPostsForCategoryFromMockApi = async (): Promise<IPost[]> => {
+  try {
+    const res = await fetch(`${process.env.NEXT_PUBLIC_MOCK_API_URL}/posts`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({ category: 'json' }),
+      cache: 'no-store',
+    });
+
+    if (!res.ok) {
+      throw new Error(`HTTP error! status: ${res.status}`);
+    }
+
+    const data: IPost[] = await res.json();
+    return data;
+  } catch (error) {
+    console.error(error);
+    throw error;
+  }
+};
+
+export const getCommodityByNameFromStagingApi = async (
+  name: string,
+): Promise<ICommodity | null> => {
+  try {
+    const res = await fetch(
+      `${process.env.NEXT_PUBLIC_STAGING_API_URL}/api/v1/trade/commodity/${name}`,
+      { cache: 'no-store' },
+    );
+
+    if (!res.ok) {
+      throw new Error(`HTTP error! status: ${res.status}`);
+    }
+
+    const data: ICommodity = await res.json();
+    return data;
+  } catch (error) {
+    console.error(error);
+    throw error;
+  }
+};

--- a/app/playground/page.client.tsx
+++ b/app/playground/page.client.tsx
@@ -11,32 +11,23 @@ import {
 } from '@chakra-ui/react';
 import { useState, useEffect } from 'react';
 
-interface Commodity {
-  commodityName: string;
-  displayName: string;
-  type: string;
-  isRare: boolean;
-}
+import { ICommodity, IPost } from '../_types';
 
 interface PageClientProps {
-  posts: {
-    id: number;
-    title: string;
-    author: string;
-  }[];
-  commodity: Commodity;
+  posts: IPost[];
+  commodity: ICommodity | null;
 }
 
 const PageClient = ({ posts, commodity }: PageClientProps) => {
-  const [clientCommodity, setClientCommodity] = useState<Commodity | undefined>(
-    undefined,
-  );
+  const [clientCommodity, setClientCommodity] = useState<
+    ICommodity | undefined
+  >(undefined);
   const [fetchError, setFetchError] = useState<Error | null>(null);
   const [isLoading, setIsLoading] = useState<boolean>(true);
 
   useEffect(() => {
     setIsLoading(true);
-    fetch('/api/v1/trade/commodity/Beer', { next: { revalidate: 1 } })
+    fetch('/api/v1/trade/commodity/Beer', { cache: 'no-store' })
       .then((res) => {
         if (!res.ok) {
           throw new Error(`HTTP error! status: ${res.status}`);

--- a/app/playground/page.client.tsx
+++ b/app/playground/page.client.tsx
@@ -1,6 +1,22 @@
 'use client';
 
-import { Alert, AlertIcon, Center, Flex, Heading } from '@chakra-ui/react';
+import {
+  Alert,
+  AlertIcon,
+  Center,
+  Code,
+  Flex,
+  Heading,
+  Spinner,
+} from '@chakra-ui/react';
+import { useState, useEffect } from 'react';
+
+interface Commodity {
+  commodityName: string;
+  displayName: string;
+  type: string;
+  isRare: boolean;
+}
 
 interface PageClientProps {
   posts: {
@@ -8,39 +24,160 @@ interface PageClientProps {
     title: string;
     author: string;
   }[];
+  commodity: Commodity;
 }
 
-const PageClient = ({ posts }: PageClientProps) => (
-  <Center width="100%">
-    <Flex flexDirection="column" gap="24px" width="100%" maxWidth="1500px">
-      <Heading
-        as="h1"
-        size={{ base: 'md', md: 'lg', lg: 'lg' }}
-        marginX={{ base: 'auto', md: '0', lg: '0' }}
-      >
-        Playground
-      </Heading>
-      Developer playground for examples of component or feature use.
-      <Heading
-        as="h2"
-        size={{ base: 'xs', md: 'sm', lg: 'md' }}
-        marginX={{ base: 'auto', md: '0', lg: '0' }}
-      >
-        Server Side Data Fetch
-      </Heading>
-      {posts?.map((item) => (
-        <div key={item.id}>
-          <p>Post Title: {item.title}</p>
-          <p>Author: {item.author}</p>
-        </div>
-      )) ?? (
+const PageClient = ({ posts, commodity }: PageClientProps) => {
+  const [clientCommodity, setClientCommodity] = useState<Commodity | undefined>(
+    undefined,
+  );
+  const [fetchError, setFetchError] = useState<Error | null>(null);
+  const [isLoading, setIsLoading] = useState<boolean>(true);
+
+  useEffect(() => {
+    setIsLoading(true);
+    fetch('/api/v1/trade/commodity/Beer', { next: { revalidate: 1 } })
+      .then((res) => {
+        if (!res.ok) {
+          throw new Error(`HTTP error! status: ${res.status}`);
+        }
+        return res.json();
+      })
+      .then((data) => {
+        setClientCommodity(data);
+      })
+      .catch((error) => {
+        setFetchError(error);
+      })
+      .finally(() => {
+        setIsLoading(false);
+      });
+  }, []);
+
+  const renderCommodityData = () => {
+    if (isLoading) {
+      return <Spinner />;
+    }
+    if (fetchError) {
+      return (
         <Alert status="error">
           <AlertIcon />
-          Failed to fetch post data
+          Failed to fetch commodity data from staging server on client side
         </Alert>
-      )}
-    </Flex>
-  </Center>
-);
+      );
+    }
+    if (clientCommodity) {
+      return <div>Commodity Name: {clientCommodity.commodityName}</div>;
+    }
+    return (
+      <Alert status="warning">
+        <AlertIcon />
+        Commodity Not Found!
+      </Alert>
+    );
+  };
+
+  return (
+    <Center width="100%">
+      <Flex flexDirection="column" gap="24px" width="100%" maxWidth="1500px">
+        <Heading as="h1" size="lg">
+          Playground
+        </Heading>
+        Developer playground for examples of component or feature use.
+        <Heading as="h2" size="md" color="orange">
+          Server Side Data Fetch
+        </Heading>
+        <p>
+          All server side calls work without having to handle CORS through a
+          proxy, since these calls trigger from the server side and not the
+          browser.
+        </p>
+        <Heading as="h2" size="md">
+          Mock Server API - POST
+        </Heading>
+        <p>
+          This approach allows you to call the JSON mock API server running
+          locally. You need to run <Code>yarn dev-api</Code> to connect to this
+          server.
+        </p>
+        <Code whiteSpace="pre">
+          {`
+  fetch(\`\${process.env.NEXT_PUBLIC_MOCK_API_URL}/posts\`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({ category: 'json' }),
+    });
+  }
+          `}
+        </Code>
+        <Heading as="h3" size="sm">
+          Response
+        </Heading>
+        {posts?.map((item) => (
+          <div key={item.id}>
+            <p>Post Title: {item.title}</p>
+            <p>Author: {item.author}</p>
+          </div>
+        )) ?? (
+          <Alert status="error">
+            <AlertIcon />
+            Failed to fetch post data from staging server on server side
+          </Alert>
+        )}
+        <Heading as="h2" size="md">
+          Staging Server API
+        </Heading>
+        <Code whiteSpace="pre">
+          {`
+  fetch(\`\${process.env.NEXT_PUBLIC_STAGING_API_URL}/api/v1/trade/commodity/\${name}\`);
+          `}
+        </Code>
+        <p>
+          This approach allows you to call the hosted backend staging server.
+          e.g., Morris API running on our Backend service. You can connect to
+          this without running the local JSON mock API i.e., just run{' '}
+          <Code>yarn dev</Code>. It will work even if you are running the JSON
+          mock API server.
+        </p>
+        <Heading as="h3" size="sm">
+          Response
+        </Heading>
+        {commodity ? (
+          <div>
+            <p>Commodity Name: {commodity.commodityName}</p>
+          </div>
+        ) : (
+          <Alert status="error">
+            <AlertIcon />
+            Failed to fetch commodity data from staging server on server side
+          </Alert>
+        )}
+        <Heading as="h2" size="md" color="orange">
+          Client Side Data Fetch
+        </Heading>
+        <p>
+          All client side calls need to handle CORS, this is where the Next JS
+          proxy config comes handy. When you call fetch without a hostname, the
+          proxy config picks on the path and routes it to the backend as a
+          server side call.
+        </p>
+        <Heading as="h2" size="md">
+          Staging Server API
+        </Heading>
+        <Code whiteSpace="pre">
+          {`
+  fetch('/api/v1/trade/commodity/Beer')
+          `}
+        </Code>
+        <Heading as="h3" size="sm">
+          Response
+        </Heading>
+        {renderCommodityData()}
+      </Flex>
+    </Center>
+  );
+};
 
 export default PageClient;

--- a/app/playground/page.test.tsx
+++ b/app/playground/page.test.tsx
@@ -1,21 +1,67 @@
-import { render, screen } from '@testing-library/react';
+import { render, screen, waitFor } from '@testing-library/react';
 import PageClient from './page.client';
 
-test('renders the heading with correct text', () => {
-  const mockPostData = [
-    {
-      id: 1,
-      title: 'json-server',
-      author: 'typicode',
-    },
-  ];
+const mockPostData = [
+  {
+    id: 1,
+    title: 'json-server',
+    author: 'typicode',
+  },
+];
 
-  render(<PageClient posts={mockPostData} />);
-  const headingElement = screen.getByRole('heading', { level: 1 });
+const mockCommodity = {
+  commodityName: 'wine',
+  displayName: 'Wine',
+  type: 'LEGAL_DRUGS',
+  isRare: false,
+};
+
+const mockClientCommodity = {
+  commodityName: 'beer',
+  displayName: 'Beer',
+  type: 'LEGAL_DRUGS',
+  isRare: false,
+};
+
+beforeEach(() => {
+  fetchMock.resetMocks();
+});
+
+test('fetches and displays the post & commodity data from server & client side calls', async () => {
+  fetchMock.mockResponseOnce(JSON.stringify(mockClientCommodity));
+  render(<PageClient posts={mockPostData} commodity={mockCommodity} />);
+
+  // Check if server returned post data is being rendered
   const postTitleElement = screen.getByText('Post Title: json-server');
   const authorElement = screen.getByText('Author: typicode');
-  expect(headingElement).toBeInTheDocument();
-  expect(headingElement.textContent).toBe('Playground');
   expect(postTitleElement).toBeInTheDocument();
   expect(authorElement).toBeInTheDocument();
+
+  // Check if server returned commodity data is being rendered
+  const commodityElement = screen.getByText('Commodity Name: wine');
+  expect(commodityElement).toBeInTheDocument();
+
+  // Check for client returned commodity data is being rendered
+  expect(fetchMock).toHaveBeenCalledWith('/api/v1/trade/commodity/Beer', {
+    next: { revalidate: 1 },
+  });
+
+  await waitFor(() =>
+    expect(screen.getByText('Commodity Name: beer')).toBeInTheDocument(),
+  );
+});
+
+test('displays an error message when the fetch request fails', async () => {
+  const errorMessage =
+    'Failed to fetch commodity data from staging server on client side';
+
+  fetchMock.mockRejectOnce(new Error(errorMessage));
+
+  render(<PageClient posts={mockPostData} commodity={mockCommodity} />);
+
+  await waitFor(() =>
+    expect(screen.getByText(errorMessage)).toBeInTheDocument(),
+  );
+
+  expect(fetchMock).toHaveBeenCalledTimes(1);
 });

--- a/app/playground/page.test.tsx
+++ b/app/playground/page.test.tsx
@@ -43,7 +43,7 @@ test('fetches and displays the post & commodity data from server & client side c
 
   // Check for client returned commodity data is being rendered
   expect(fetchMock).toHaveBeenCalledWith('/api/v1/trade/commodity/Beer', {
-    next: { revalidate: 1 },
+    cache: 'no-store',
   });
 
   await waitFor(() =>

--- a/app/playground/page.tsx
+++ b/app/playground/page.tsx
@@ -1,54 +1,29 @@
 import { Metadata } from 'next';
 import PageClient from './page.client';
+import {
+  getPostsForCategoryFromMockApi,
+  getCommodityByNameFromStagingApi,
+} from './_api';
+import { ICommodity, IPost } from '../_types';
 
 export const metadata: Metadata = {
   title: 'EDPN Playground',
   description: 'Elite Dangerous Pilots Network',
-  icons: 'EDPN_logo_black.png',
+  icons: 'EDPN_logo_dark_background.png',
 };
 
-async function getPostsForCategoryWithPost() {
-  const res = await fetch(`${process.env.NEXT_PUBLIC_MOCK_API_URL}/posts`, {
-    method: 'POST',
-    headers: {
-      'Content-Type': 'application/json',
-    },
-    body: JSON.stringify({ category: 'json' }),
-    next: { revalidate: 1 },
-  });
-
-  if (!res.ok) {
-    return null;
-  }
-
-  return res.json();
-}
-
-async function getCommodityByName(name: string) {
-  const res = await fetch(
-    `${process.env.NEXT_PUBLIC_STAGING_API_URL}/api/v1/trade/commodity/${name}`,
-    { next: { revalidate: 1 } },
-  );
-
-  if (!res.ok) {
-    return null;
-  }
-
-  return res.json();
-}
-
 export default async function Page() {
-  let posts;
-  let commodity = null;
+  let posts: IPost[] = [];
+  let commodity: ICommodity | null = null;
 
   try {
-    posts = await getPostsForCategoryWithPost();
+    posts = await getPostsForCategoryFromMockApi();
   } catch (error) {
     console.error('Failed to fetch posts data:', error);
   }
 
   try {
-    commodity = await getCommodityByName('Wine');
+    commodity = await getCommodityByNameFromStagingApi('Wine');
   } catch (error) {
     console.error('Failed to fetch commodity data:', error);
   }

--- a/app/playground/page.tsx
+++ b/app/playground/page.tsx
@@ -7,35 +7,14 @@ export const metadata: Metadata = {
   icons: 'EDPN_logo_black.png',
 };
 
-/** Example GET calls
-async function getPosts() {
-  const res = await fetch(`${process.env.NEXT_PUBLIC_API_URL}/posts`);
-
-  if (!res.ok) {
-    return null;
-  }
-
-  return res.json();
-}
-
-async function getPostsForCategory() {
-  const res = await fetch(`${process.env.NEXT_PUBLIC_API_URL}/posts/json`);
-  if (!res.ok) {
-    return null;
-  }
-
-  return res.json();
-}
-*/
-
-// Example fetch with POST instead of GET. Relies on middlware to change mock API to GET
 async function getPostsForCategoryWithPost() {
-  const res = await fetch(`${process.env.NEXT_PUBLIC_API_URL}/posts`, {
+  const res = await fetch(`${process.env.NEXT_PUBLIC_MOCK_API_URL}/posts`, {
     method: 'POST',
     headers: {
       'Content-Type': 'application/json',
     },
     body: JSON.stringify({ category: 'json' }),
+    next: { revalidate: 1 },
   });
 
   if (!res.ok) {
@@ -45,14 +24,34 @@ async function getPostsForCategoryWithPost() {
   return res.json();
 }
 
+async function getCommodityByName(name: string) {
+  const res = await fetch(
+    `${process.env.NEXT_PUBLIC_STAGING_API_URL}/api/v1/trade/commodity/${name}`,
+    { next: { revalidate: 1 } },
+  );
+
+  if (!res.ok) {
+    return null;
+  }
+
+  return res.json();
+}
+
 export default async function Page() {
-  let posts = null;
+  let posts;
+  let commodity = null;
 
   try {
     posts = await getPostsForCategoryWithPost();
   } catch (error) {
-    console.error('Failed to fetch data:', error);
+    console.error('Failed to fetch posts data:', error);
   }
 
-  return <PageClient posts={posts} />;
+  try {
+    commodity = await getCommodityByName('Wine');
+  } catch (error) {
+    console.error('Failed to fetch commodity data:', error);
+  }
+
+  return <PageClient posts={posts} commodity={commodity} />;
 }

--- a/jest.setup.js
+++ b/jest.setup.js
@@ -4,6 +4,9 @@
 // Used for __tests__/testing-library.js
 // Learn more: https://github.com/testing-library/jest-dom
 import '@testing-library/jest-dom/extend-expect';
+import fetchMock from 'jest-fetch-mock';
+
+fetchMock.enableMocks();
 
 // Mock matchMedia
 global.matchMedia = () => ({

--- a/next.config.js
+++ b/next.config.js
@@ -10,6 +10,14 @@ const nextConfig = {
     domains: ['edpn.com'],
   },
   eslint: { dirs: ['.'] },
+  async rewrites() {
+    return [
+      {
+        source: '/api/:path*',
+        destination: 'http://morris.edpn.io:8080/api/:path*',
+      },
+    ];
+  },
 };
 
 module.exports = withBundleAnalyzer(nextConfig);

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "build": "next build",
     "start": "next start",
     "lint": "next lint",
+    "lint:fix": "next lint --fix",
     "prepare": "husky install",
     "prettier": "prettier --write .",
     "analyze": "ANALYZE=true yarn build",
@@ -62,6 +63,7 @@
     "husky": "^8.0.0",
     "jest": "^29.5.0",
     "jest-environment-jsdom": "^29.5.0",
+    "jest-fetch-mock": "^3.0.3",
     "prettier": "^2.8.8"
   },
   "engines": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2736,6 +2736,13 @@ cosmiconfig@^7.0.0:
     path-type "^4.0.0"
     yaml "^1.10.0"
 
+cross-fetch@^3.0.4:
+  version "3.1.8"
+  resolved "https://registry.yarnpkg.com/cross-fetch/-/cross-fetch-3.1.8.tgz#0327eba65fd68a7d119f8fb2bf9334a1a7956f82"
+  integrity sha512-cvA+JwZoU0Xq+h6WkMvAUqPEYy92Obet6UdKLfW60qn99ftItKjB5T+BkyWOFWe2pUyfQ+IJHmpOTznqk1M6Kg==
+  dependencies:
+    node-fetch "^2.6.12"
+
 cross-spawn@^7.0.2, cross-spawn@^7.0.3:
   version "7.0.3"
   resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-7.0.3.tgz#f73a85b9d5d41d045551c177e2882d4ac85728a6"
@@ -4570,6 +4577,14 @@ jest-environment-node@^29.5.0:
     jest-mock "^29.5.0"
     jest-util "^29.5.0"
 
+jest-fetch-mock@^3.0.3:
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/jest-fetch-mock/-/jest-fetch-mock-3.0.3.tgz#31749c456ae27b8919d69824f1c2bd85fe0a1f3b"
+  integrity sha512-Ux1nWprtLrdrH4XwE7O7InRY6psIi3GOsqNESJgMJ+M5cv4A8Lh7SN9d2V2kKRZ8ebAfcd1LNyZguAOb6JiDqw==
+  dependencies:
+    cross-fetch "^3.0.4"
+    promise-polyfill "^8.1.3"
+
 jest-get-type@^29.4.3:
   version "29.4.3"
   resolved "https://registry.yarnpkg.com/jest-get-type/-/jest-get-type-29.4.3.tgz#1ab7a5207c995161100b5187159ca82dd48b3dd5"
@@ -5259,6 +5274,13 @@ next@13.4.4:
     "@next/swc-win32-ia32-msvc" "13.4.4"
     "@next/swc-win32-x64-msvc" "13.4.4"
 
+node-fetch@^2.6.12:
+  version "2.6.12"
+  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.12.tgz#02eb8e22074018e3d5a83016649d04df0e348fba"
+  integrity sha512-C/fGU2E8ToujUivIO0H+tpQ6HWo4eEmchoPIoXtxCrVghxdKq+QOHqEZW7tuP3KlV3bC8FRMO5nMCC7Zm1VP6g==
+  dependencies:
+    whatwg-url "^5.0.0"
+
 node-int64@^0.4.0:
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/node-int64/-/node-int64-0.4.0.tgz#87a9065cdb355d3182d8f94ce11188b825c68a3b"
@@ -5681,6 +5703,11 @@ pretty-format@^29.0.0, pretty-format@^29.5.0:
     "@jest/schemas" "^29.4.3"
     ansi-styles "^5.0.0"
     react-is "^18.0.0"
+
+promise-polyfill@^8.1.3:
+  version "8.3.0"
+  resolved "https://registry.yarnpkg.com/promise-polyfill/-/promise-polyfill-8.3.0.tgz#9284810268138d103807b11f4e23d5e945a4db63"
+  integrity sha512-H5oELycFml5yto/atYqmjyigJoAo3+OXwolYiH7OfQuYlAqhxNvTfiNMbV9hsC6Yp83yE5r2KTVmtrG6R9i6Pg==
 
 prompts@^2.0.1:
   version "2.4.2"
@@ -6467,6 +6494,11 @@ tr46@^3.0.0:
   dependencies:
     punycode "^2.1.1"
 
+tr46@~0.0.3:
+  version "0.0.3"
+  resolved "https://registry.yarnpkg.com/tr46/-/tr46-0.0.3.tgz#8184fd347dac9cdc185992f3a6622e14b9d9ab6a"
+  integrity sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==
+
 tree-kill@^1.2.2:
   version "1.2.2"
   resolved "https://registry.yarnpkg.com/tree-kill/-/tree-kill-1.2.2.tgz#4ca09a9092c88b73a7cdc5e8a01b507b0790a0cc"
@@ -6666,6 +6698,11 @@ walker@^1.0.8:
   dependencies:
     makeerror "1.0.12"
 
+webidl-conversions@^3.0.0:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/webidl-conversions/-/webidl-conversions-3.0.1.tgz#24534275e2a7bc6be7bc86611cc16ae0a5654871"
+  integrity sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==
+
 webidl-conversions@^7.0.0:
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/webidl-conversions/-/webidl-conversions-7.0.0.tgz#256b4e1882be7debbf01d05f0aa2039778ea080a"
@@ -6705,6 +6742,14 @@ whatwg-url@^11.0.0:
   dependencies:
     tr46 "^3.0.0"
     webidl-conversions "^7.0.0"
+
+whatwg-url@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/whatwg-url/-/whatwg-url-5.0.0.tgz#966454e8765462e37644d3626f6742ce8b70965d"
+  integrity sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==
+  dependencies:
+    tr46 "~0.0.3"
+    webidl-conversions "^3.0.0"
 
 which-boxed-primitive@^1.0.2:
   version "1.0.2"


### PR DESCRIPTION
- Adds proxy setup (for CORS)  to call morris endpoint from client side rendering code with fetch
- Adds examples of calling morris endpoint from server side without needed proxy
- Adds documentation and updates the playground page to show how to use the mock-api and the proxy in coordination
- Updated server stage render to switch to Badge
- Adds a button icon on top right to link to the playground page. Only visible in local development
- Configures jest to mock fetch calls in unit tests
- Adds unit tests for playground handling server side response rendering and client side fetch

**Full Playground View**
![EDPN-Playground](https://github.com/ed-pilots-network/frontend/assets/1340144/90696067-75c0-4e25-98a5-a061aecb34e8)

**Error State Playground**
![Screen Shot 2023-07-29 at 4 10 25 AM](https://github.com/ed-pilots-network/frontend/assets/1340144/d1a2d974-746d-4bbb-91ee-fa17fb2de196)
