### PR TITLE
Lock Yarn version to 1

### DIFF
--- a/package.json
+++ b/package.json
@@ -69,5 +69,6 @@
     "yarn": ">= 1.22.19",
     "npm": "Please use Yarn instead of NPM.",
     "pnpm": "Please use Yarn instead of NPM."
-  }
+  },
+  "packageManager": "yarn@1.22.19"
 }


### PR DESCRIPTION
This locks the yarn version used in the project to v1. If you're using the latest version of yarn locally (ie v3), running the `yarn` command will see this, download the correct version, and force it to use that version.

Without this, running `yarn` rewrites the lockfile leaving you with something similar to this:

![image](https://github.com/ed-pilots-network/frontend/assets/319883/2b77f782-3a0b-498c-a3c1-8f77f6aa2110)
