### PR TITLE
Setup playwright to use standalone server instead of start for tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "dev-api": "concurrently \"next dev\" \"yarn api\"",
     "api": "node mock-api/server.js",
     "build": "next build",
+    "copy-standalone-assets": "cp -R .next/static .next/standalone/.next && cp -R public .next/standalone",
     "start": "next start",
     "lint": "next lint",
     "lint:fix": "next lint --fix",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -20,7 +20,8 @@ const config: PlaywrightTestConfig = {
   // Run your local dev server before starting the tests:
   // https://playwright.dev/docs/test-advanced#launching-a-development-web-server-during-the-tests
   webServer: {
-    command: 'yarn build && yarn start',
+    command:
+      'yarn build && yarn copy-standalone-assets && node .next/standalone/server.js',
     url: baseURL,
     timeout: 120 * 1000,
     reuseExistingServer: !process.env.CI,


### PR DESCRIPTION
Running standalone server needs copying some assets as we do in our docker setup as well. Replicating that to drop warnings for using next start