### PR TITLE
Switch to CSS based responsive handling over JS based

### DIFF
--- a/app/_components/navbar/Navbar.tsx
+++ b/app/_components/navbar/Navbar.tsx
@@ -1,13 +1,12 @@
 import {
   Badge,
+  Box,
   Menu,
   MenuButton,
   Flex,
   IconButton,
   Text,
   Image,
-  Hide,
-  Show,
   LinkBox,
   LinkOverlay,
   Popover,
@@ -45,9 +44,9 @@ const Navbar = () => {
         maxWidth={layoutConfig.maxWidth}
       >
         <Flex alignItems="center">
-          <Show below="md">
+          <Box display={{ base: 'flex', md: 'none' }}>
             <NavDrawer />
-          </Show>
+          </Box>
           <Link href="/">
             <Image
               src={'/EDPN_logo_dark_background.png'}
@@ -68,7 +67,7 @@ const Navbar = () => {
             </Text>
           </Link>
 
-          <Hide below="md">
+          <Box display={{ base: 'none', md: 'flex' }}>
             {Tags.map((tag) => (
               <Popover key={tag} trigger="click" placement="bottom-start">
                 <PopoverTrigger>
@@ -112,11 +111,11 @@ const Navbar = () => {
                 </PopoverContent>
               </Popover>
             ))}
-          </Hide>
+          </Box>
         </Flex>
 
         <Flex justifyContent="space-between" alignItems="center">
-          <Hide below="md">
+          <Box display={{ base: 'none', md: 'flex' }}>
             <Badge
               margin={2}
               px={2}
@@ -125,7 +124,7 @@ const Navbar = () => {
             >
               {process.env.NEXT_PUBLIC_STAGE}
             </Badge>
-          </Hide>
+          </Box>
           {process.env.NEXT_PUBLIC_STAGE === 'localhost' && (
             <Menu>
               <Link href="/playground" prefetch={false}>


### PR DESCRIPTION
Use of Show/Hide components isn't effective, especially for when using Hide, as this waits for the JS to process this media query. Recommended way is to just stick to CSS based media queries and not wait for JS to make those view decisions.

Also recommended in Chakra issues - https://github.com/chakra-ui/chakra-ui/issues/5773#issuecomment-1079937398

Closes https://github.com/ed-pilots-network/frontend/issues/75

![screenshot-Desktop-Chrome-480x720-dark](https://github.com/ed-pilots-network/frontend/assets/1340144/f8f9be13-ad18-42bb-9d6c-27ec27d902f1)
![screenshot-Desktop-Chrome-768x1024-dark](https://github.com/ed-pilots-network/frontend/assets/1340144/77595ed5-108a-4379-9dc3-ea825acc6b0c)
