### PR TITLE
Sets default font weight & fixes font loading in local dev

### DIFF
--- a/app/_config/theme/fonts.ts
+++ b/app/_config/theme/fonts.ts
@@ -2,11 +2,13 @@ import localFont from 'next/font/local';
 import { Orbitron, Rubik } from 'next/font/google';
 
 export const orbitron = Orbitron({
+  weight: ['400'],
   subsets: ['latin'],
   display: 'swap',
 });
 
 export const rubik = Rubik({
+  weight: ['400'],
   subsets: ['latin'],
   display: 'swap',
 });


### PR DESCRIPTION
Possible issue with picking defaults when running local development. [NextJs Docs](https://nextjs.org/docs/app/building-your-application/optimizing/fonts) mention that weights should be defined when not using variable fonts but these are variable fonts. Could be some issue, anyway, adding weight fixes it locally.

Fixes https://github.com/ed-pilots-network/frontend/issues/61