### PR TITLE
Exact then Fuzzy sorting

### DIFF
--- a/app/_components/inputs/Commodities.tsx
+++ b/app/_components/inputs/Commodities.tsx
@@ -4,7 +4,7 @@ import { Controller } from 'react-hook-form';
 import SelectStyles from '@/app/_hooks/SelectStyles';
 import { ICommodity } from '@/app/_types';
 import { useState } from 'react';
-import exactThenFuzzySort from '@/app/_lib/utils/sort';
+import { exactThenFuzzySort } from '@/app/_lib/utils/sort';
 
 interface CommodityProps {
   control: any;

--- a/app/_components/inputs/Commodities.tsx
+++ b/app/_components/inputs/Commodities.tsx
@@ -3,6 +3,8 @@ import { Controller } from 'react-hook-form';
 
 import SelectStyles from '@/app/_hooks/SelectStyles';
 import { ICommodity } from '@/app/_types';
+import { useState } from 'react';
+import exactThenFuzzy from '@/app/_lib/utils/sort';
 
 interface CommodityProps {
   control: any;
@@ -40,6 +42,8 @@ const CommoditiesField: React.FC<CommodityProps> = ({
     }));
   }
 
+  const [options, setOptions] = useState(formattedCommodities);
+
   const fieldOptions: FieldOptions = {};
   if (isMulti) {
     fieldOptions.isMulti = true;
@@ -56,10 +60,13 @@ const CommoditiesField: React.FC<CommodityProps> = ({
           instanceId="commodityDisplayName"
           name={name}
           ref={ref}
+          onInputChange={(input) => {
+            exactThenFuzzy(input, formattedCommodities, setOptions);
+          }}
           onChange={onChange}
           onBlur={onBlur}
           value={value}
-          options={formattedCommodities}
+          options={options}
           placeholder={placeholder}
           chakraStyles={SelectStyles()}
           {...fieldOptions}

--- a/app/_components/inputs/Commodities.tsx
+++ b/app/_components/inputs/Commodities.tsx
@@ -4,7 +4,7 @@ import { Controller } from 'react-hook-form';
 import SelectStyles from '@/app/_hooks/SelectStyles';
 import { ICommodity } from '@/app/_types';
 import { useState } from 'react';
-import exactThenFuzzy from '@/app/_lib/utils/sort';
+import exactThenFuzzySort from '@/app/_lib/utils/sort';
 
 interface CommodityProps {
   control: any;
@@ -61,7 +61,7 @@ const CommoditiesField: React.FC<CommodityProps> = ({
           name={name}
           ref={ref}
           onInputChange={(input) => {
-            exactThenFuzzy(input, formattedCommodities, setOptions);
+            exactThenFuzzySort(input, formattedCommodities, setOptions);
           }}
           onChange={onChange}
           onBlur={onBlur}

--- a/app/_components/inputs/Modules.tsx
+++ b/app/_components/inputs/Modules.tsx
@@ -2,7 +2,7 @@ import { Controller } from 'react-hook-form';
 import { Select, OptionBase, GroupBase } from 'chakra-react-select';
 import SelectStyles from '@/app/_hooks/SelectStyles';
 import modules from '@/app/_lib/module-list';
-import exactThenFuzzySort from '@/app/_lib/utils/sort';
+import { exactThenFuzzySort } from '@/app/_lib/utils/sort';
 import { useState } from 'react';
 
 interface Props {

--- a/app/_components/inputs/Modules.tsx
+++ b/app/_components/inputs/Modules.tsx
@@ -2,6 +2,8 @@ import { Controller } from 'react-hook-form';
 import { Select, OptionBase, GroupBase } from 'chakra-react-select';
 import SelectStyles from '@/app/_hooks/SelectStyles';
 import modules from '@/app/_lib/module-list';
+import exactThenFuzzySort from '@/app/_lib/utils/sort';
+import { useState } from 'react';
 
 interface Props {
   control: any;
@@ -37,6 +39,9 @@ const ModulesField = ({
   if (isMulti) {
     fieldOptions.isMulti = true;
   }
+
+  const [options, setOptions] = useState(getOptions());
+
   return (
     <Controller
       name="modules"
@@ -47,10 +52,13 @@ const ModulesField = ({
           instanceId="modules-field"
           name={name}
           ref={ref}
+          onInputChange={(input) => {
+            exactThenFuzzySort(input, getOptions(), setOptions);
+          }}
           onChange={onChange}
           onBlur={onBlur}
           value={value}
-          options={getOptions()}
+          options={options}
           placeholder={placeholder}
           chakraStyles={SelectStyles()}
           {...fieldOptions}

--- a/app/_components/inputs/Ships.tsx
+++ b/app/_components/inputs/Ships.tsx
@@ -2,6 +2,8 @@ import { Controller } from 'react-hook-form';
 import { Select, OptionBase, GroupBase } from 'chakra-react-select';
 import SelectStyles from '@/app/_hooks/SelectStyles';
 import ships from '@/app/_lib/ship-list';
+import { useState } from 'react';
+import exactThenFuzzySort from '@/app/_lib/utils/sort';
 
 interface Props {
   control: any;
@@ -38,6 +40,8 @@ const ShipsField = ({
     fieldOptions.isMulti = true;
   }
 
+  const [options, setOptions] = useState(getOptions());
+
   return (
     <Controller
       name="ships"
@@ -48,10 +52,13 @@ const ShipsField = ({
           instanceId="ships-field"
           name={name}
           ref={ref}
+          onInputChange={(input) => {
+            exactThenFuzzySort(input, getOptions(), setOptions);
+          }}
           onChange={onChange}
           onBlur={onBlur}
           value={value}
-          options={getOptions()}
+          options={options}
           placeholder={placeholder}
           chakraStyles={SelectStyles()}
           {...fieldOptions}

--- a/app/_components/inputs/Ships.tsx
+++ b/app/_components/inputs/Ships.tsx
@@ -3,7 +3,7 @@ import { Select, OptionBase, GroupBase } from 'chakra-react-select';
 import SelectStyles from '@/app/_hooks/SelectStyles';
 import ships from '@/app/_lib/ship-list';
 import { useState } from 'react';
-import exactThenFuzzySort from '@/app/_lib/utils/sort';
+import { exactThenFuzzySort } from '@/app/_lib/utils/sort';
 
 interface Props {
   control: any;

--- a/app/_lib/utils/sort.test.ts
+++ b/app/_lib/utils/sort.test.ts
@@ -1,0 +1,49 @@
+import { OptionBase } from 'chakra-react-select';
+import { exactThenFuzzySort } from './sort';
+
+interface SelectItem extends OptionBase {
+  label: string;
+  value: string;
+}
+
+describe('exact then fuzzy sort', () => {
+  it('should sort exact matches first then alphabetical', () => {
+    let sortedOptions: SelectItem[] = [];
+
+    const mockData = [
+      { label: 'ddcrad', value: 'ddcrad' },
+      { label: 'craccc', value: 'craccc' },
+      { label: 'bbcrab', value: 'bbcrab' },
+      { label: 'aaacra', value: 'aaacra' },
+      { label: 'eeecra', value: 'eeecra' },
+    ];
+
+    exactThenFuzzySort('cra', mockData, (sortedMockData) => {
+      sortedOptions = sortedMockData;
+    });
+
+    expect(sortedOptions[0].label).toEqual('craccc');
+    expect(sortedOptions[1].label).toEqual('aaacra');
+    expect(sortedOptions[2].label).toEqual('bbcrab');
+    expect(sortedOptions[3].label).toEqual('ddcrad');
+    expect(sortedOptions[4].label).toEqual('eeecra');
+  });
+
+  it('is case insensitive', () => {
+    let sortedOptions: SelectItem[] = [];
+
+    const mockData = [
+      { label: 'DDCRAD', value: 'ddcrad' },
+      { label: 'CRACC', value: 'craccc' },
+      { label: 'BBCRAB', value: 'bbcrab' },
+    ];
+
+    exactThenFuzzySort('cra', mockData, (sortedMockData) => {
+      sortedOptions = sortedMockData;
+    });
+
+    expect(sortedOptions[0].label).toEqual('CRACC');
+    expect(sortedOptions[1].label).toEqual('BBCRAB');
+    expect(sortedOptions[2].label).toEqual('DDCRAD');
+  });
+});

--- a/app/_lib/utils/sort.ts
+++ b/app/_lib/utils/sort.ts
@@ -5,7 +5,17 @@ interface SelectItem extends OptionBase {
   value: string;
 }
 
-const exactThenFuzzySort = (
+export const alphabeticalSort = (a: SelectItem, b: SelectItem) => {
+  if (a.label < b.label) {
+    return -1;
+  }
+  if (a.label > b.label) {
+    return 1;
+  }
+  return 0;
+};
+
+export const exactThenFuzzySort = (
   input: string,
   options: SelectItem[],
   after: (sortedOptions: SelectItem[]) => void,
@@ -22,9 +32,7 @@ const exactThenFuzzySort = (
     }
   }
 
-  exact.sort();
-  fuzzy.sort();
+  exact.sort(alphabeticalSort);
+  fuzzy.sort(alphabeticalSort);
   after(exact.concat(fuzzy));
 };
-
-export default exactThenFuzzySort;

--- a/app/_lib/utils/sort.ts
+++ b/app/_lib/utils/sort.ts
@@ -1,0 +1,30 @@
+import { OptionBase } from 'chakra-react-select';
+
+interface SelectItem extends OptionBase {
+  label: string;
+  value: string;
+}
+
+const exactThenFuzzy = (
+  input: string,
+  options: SelectItem[],
+  after: (sortedOptions: SelectItem[]) => void,
+) => {
+  const exact = [];
+  const fuzzy = [];
+  const check = (input === '' ? 'a' : input).toLowerCase();
+
+  for (let i = 0; i < options.length; i += 1) {
+    if (options[i].label.toLowerCase().indexOf(check) === 0) {
+      exact.push(options[i]);
+    } else {
+      fuzzy.push(options[i]);
+    }
+  }
+
+  exact.sort();
+  fuzzy.sort();
+  after(exact.concat(fuzzy));
+};
+
+export default exactThenFuzzy;

--- a/app/_lib/utils/sort.ts
+++ b/app/_lib/utils/sort.ts
@@ -5,7 +5,7 @@ interface SelectItem extends OptionBase {
   value: string;
 }
 
-const exactThenFuzzy = (
+const exactThenFuzzySort = (
   input: string,
   options: SelectItem[],
   after: (sortedOptions: SelectItem[]) => void,
@@ -27,4 +27,4 @@ const exactThenFuzzy = (
   after(exact.concat(fuzzy));
 };
 
-export default exactThenFuzzy;
+export default exactThenFuzzySort;


### PR DESCRIPTION
Generic sorting function for react-select inputs

Orders search results by matches that begin with your search phrase (alphabetically) then partial matches (alphabetically)

So a search for "tri" will return Tritium before Ion Cartiridges

Have made it an external function as I assume this sorting strategy will probably be what we want to use for most if not all of the react-select dropdowns

closes #123 