### PR TITLE
Fix tab underlines on home screen

### DIFF
--- a/app/_components/module-launch-pad/ModuleLaunchPad.tsx
+++ b/app/_components/module-launch-pad/ModuleLaunchPad.tsx
@@ -71,6 +71,7 @@ const ModuleLaunchPad = () => {
     <Tab
       _selected={{
         color: GetColor('textSelected'),
+        borderBottom: '2px solid',
       }}
       aria-label={`Toggle ${text} Tab`}
       textTransform="capitalize"
@@ -107,12 +108,7 @@ const ModuleLaunchPad = () => {
       minHeight="100%"
       colorScheme={GetColor('text')}
     >
-      <TabList
-        display="flex"
-        gap="2rem"
-        flexWrap="wrap"
-        borderBottom="2px solid"
-      >
+      <TabList display="flex" gap="2rem" flexWrap="wrap">
         {Tags.map((tag) => renderTab(tag))}
       </TabList>
       <TabPanels mt="20px" minHeight="400px">


### PR DESCRIPTION
The large line below the tab list is now much more subtle and the selected tab now has an accent underline.

![Screenshot 2023-09-21 at 12-18-32 EDPN Home](https://github.com/ed-pilots-network/frontend/assets/50422789/d89065e0-287c-4c46-a1b1-f78773c5d327)
