### PR TITLE
Single trade system search api integration, form update

### DIFF
--- a/.env
+++ b/.env
@@ -1,3 +1,3 @@
 NEXT_PUBLIC_STAGE=localhost
 NEXT_PUBLIC_MOCK_API_URL=http://localhost:3001
-NEXT_PUBLIC_STAGING_API_URL=http://morris.edpn.io:8080
+NEXT_PUBLIC_STAGING_API_URL=http://duval.edpn.io:8080

--- a/app/_components/inputs/Systems.tsx
+++ b/app/_components/inputs/Systems.tsx
@@ -30,28 +30,51 @@ type FieldOptions = {
 };
 
 /* Swap out for live lookup when data is available? */
-const loadOptions = async (inputValue: string) => {
+const getMockSystemName = async (lookupString: string) => {
+  const res = await fetch(
+    `${process.env.NEXT_PUBLIC_MOCK_API_URL}/api/v1/exploration/system/by-name-containing`,
+    {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({ name: lookupString }),
+    },
+  );
+
+  if (!res.ok) {
+    throw new Error(`HTTP error! status: ${res.status}`);
+  }
+
+  return res.json();
+};
+
+const loadOptions = async (inputValue: string): Promise<SelectGroup[] | []> => {
   if (inputValue.length < 3) {
     return [];
   }
 
-  const data = await fetch(
-    `${process.env.NEXT_PUBLIC_MOCK_API_URL}/api/v1/exploration/system/by-name-containing`,
-  )
-    .then((response) => response.json())
-    .then((response) =>
-      response.map((item: ISystem) => ({
-        value: item.eliteId,
-        label: item.name,
-      })),
-    )
-    .then((final) =>
-      final.filter((i: SelectGroup) =>
-        i.label.toLowerCase().includes(inputValue.toLowerCase()),
-      ),
+  try {
+    let res = [];
+
+    if (process.env.NODE_ENV === 'development')
+      res = await getMockSystemName(inputValue);
+
+    const returnArr: SelectGroup[] = res.map((item: ISystem) => ({
+      value: item.eliteId,
+      label: item.name,
+    }));
+
+    const returnArrFiltered = returnArr.filter((i: SelectGroup) =>
+      i.label.toLowerCase().includes(inputValue.toLowerCase()),
     );
 
-  return data;
+    return returnArrFiltered;
+  } catch (error) {
+    if (process.env.NODE_ENV === 'development')
+      console.error({ message: 'Failed fetching system name', error });
+    return [];
+  }
 };
 
 const SystemsField = ({

--- a/app/_components/inputs/Systems.tsx
+++ b/app/_components/inputs/Systems.tsx
@@ -49,6 +49,18 @@ const getMockSystemName = async (lookupString: string) => {
   return res.json();
 };
 
+const getSystemName = async (lookupString: string) => {
+  const res = await fetch(
+    `${process.env.NEXT_PUBLIC_STAGING_API_URL}/api/v1/exploration/system/by-name-containing?subString=${lookupString}&amount=10`,
+  );
+
+  if (!res.ok) {
+    throw new Error(`HTTP error! status: ${res.status}`);
+  }
+
+  return res.json();
+};
+
 const loadOptions = async (inputValue: string): Promise<SelectGroup[] | []> => {
   if (inputValue.length < 3) {
     return [];
@@ -57,8 +69,11 @@ const loadOptions = async (inputValue: string): Promise<SelectGroup[] | []> => {
   try {
     let res = [];
 
-    if (process.env.NODE_ENV === 'development')
+    if (process.env.NODE_ENV === 'development') {
       res = await getMockSystemName(inputValue);
+    } else {
+      res = await getSystemName(inputValue);
+    }
 
     const returnArr: SelectGroup[] = res.map((item: ISystem) => ({
       value: item.eliteId,

--- a/app/_components/trade-routes/multi/Form.tsx
+++ b/app/_components/trade-routes/multi/Form.tsx
@@ -30,9 +30,15 @@ import Select from '../../inputs/form/Select';
 import { ICommodity } from '@/app/_types';
 
 export const MultiTradeRouteFormSchema = z.object({
-  startSystem: z.object({ value: z.number() }),
+  startSystem: z
+    .object({ label: z.string() })
+    .optional()
+    .transform((val) => val?.label),
   startStation: z.string().optional(),
-  finishSystem: z.object({ value: z.number() }).optional(),
+  finishSystem: z
+    .object({ label: z.string() })
+    .optional()
+    .transform((val) => val?.label),
   commodityId: z.array(z.object({ value: z.string() })).optional(),
 
   maxHopDistance: z.string().optional(),
@@ -40,9 +46,14 @@ export const MultiTradeRouteFormSchema = z.object({
   minSupply: z.string().optional(),
   minDemand: z.string().optional(),
   maxPriceAge: z.string().optional(),
-  cargoCapacity: z.string().optional(),
-  availableCredits: z.string().optional(),
-
+  cargoCapacity: z
+    .string()
+    .optional()
+    .transform((val) => Number(val)),
+  availableCredits: z
+    .string()
+    .optional()
+    .transform((val) => Number(val)),
   government: z
     .enum(['', ...(governments.map((item) => item) as [string, ...string[]])])
     .optional(),

--- a/app/_components/trade-routes/multi/Form.tsx
+++ b/app/_components/trade-routes/multi/Form.tsx
@@ -45,7 +45,7 @@ export const MultiTradeRouteFormSchema = z.object({
   maxHopCount: z.string().optional(),
   minSupply: z.string().optional(),
   minDemand: z.string().optional(),
-  maxPriceAge: z.string().optional(),
+  maxPriceAge: z.number().optional(),
   cargoCapacity: z
     .string()
     .optional()

--- a/app/_components/trade-routes/single/Form.test.tsx
+++ b/app/_components/trade-routes/single/Form.test.tsx
@@ -10,30 +10,6 @@ jest.mock('../../inputs/Systems', () => ({
       <input value="some value" onChange={(e) => e.target.value} />,
     ),
 }));
-jest.mock('../../inputs/Governments', () => ({
-  __esModule: true,
-  default: jest
-    .fn()
-    .mockReturnValue(
-      <input
-        aria-label="governments"
-        value="some value"
-        onChange={(e) => e.target.value}
-      />,
-    ),
-}));
-jest.mock('../../inputs/Allegiances', () => ({
-  __esModule: true,
-  default: jest
-    .fn()
-    .mockReturnValue(
-      <input
-        aria-label="allegiances"
-        value="some value"
-        onChange={(e) => e.target.value}
-      />,
-    ),
-}));
 jest.mock('../../inputs/LandingPads', () => ({
   __esModule: true,
   default: jest
@@ -58,18 +34,6 @@ jest.mock('../../inputs/StationTypes', () => ({
       />,
     ),
 }));
-jest.mock('../../inputs/Powers', () => ({
-  __esModule: true,
-  default: jest
-    .fn()
-    .mockReturnValue(
-      <input
-        aria-label="powers"
-        value="some value"
-        onChange={(e) => e.target.value}
-      />,
-    ),
-}));
 
 describe('Stations Form', () => {
   it('renders the fields', () => {
@@ -81,10 +45,6 @@ describe('Stations Form', () => {
 
     expect(
       screen.getByRole('combobox', { name: 'Buy from Station' }),
-    ).toBeInTheDocument();
-
-    expect(
-      screen.getByRole('combobox', { name: 'Sell to Station' }),
     ).toBeInTheDocument();
 
     expect(
@@ -121,22 +81,12 @@ describe('Stations Form', () => {
 
     /* Mocked abstracted fields */
     expect(
-      screen.getByRole('textbox', { name: 'governments' }),
-    ).toBeInTheDocument();
-
-    expect(
-      screen.getByRole('textbox', { name: 'allegiances' }),
-    ).toBeInTheDocument();
-
-    expect(
       screen.getByRole('textbox', { name: 'landingPads' }),
     ).toBeInTheDocument();
 
     expect(
       screen.getByRole('textbox', { name: 'stationTypes' }),
     ).toBeInTheDocument();
-
-    expect(screen.getByRole('textbox', { name: 'powers' })).toBeInTheDocument();
 
     expect(
       screen.getByRole('button', { name: /Find Routes/i }),

--- a/app/_components/trade-routes/single/Form.test.tsx
+++ b/app/_components/trade-routes/single/Form.test.tsx
@@ -48,7 +48,11 @@ describe('Stations Form', () => {
     ).toBeInTheDocument();
 
     expect(
-      screen.getByRole('spinbutton', { name: 'Max Hop Distance' }),
+      screen.getByRole('combobox', { name: 'Sell to Station' }),
+    ).toBeInTheDocument();
+
+    expect(
+      screen.getByRole('spinbutton', { name: 'Max Route Distance' }),
     ).toBeInTheDocument();
 
     expect(
@@ -60,19 +64,11 @@ describe('Stations Form', () => {
     ).toBeInTheDocument();
 
     expect(
-      screen.getByRole('spinbutton', { name: 'Min. Supply' }),
-    ).toBeInTheDocument();
-
-    expect(
-      screen.getByRole('spinbutton', { name: 'Min. Demand' }),
-    ).toBeInTheDocument();
-
-    expect(
       screen.getByRole('spinbutton', { name: 'Available Credits' }),
     ).toBeInTheDocument();
 
     expect(
-      screen.getByRole('spinbutton', { name: 'Max Price Age' }),
+      screen.getByRole('combobox', { name: 'Max Price Age' }),
     ).toBeInTheDocument();
 
     expect(

--- a/app/_components/trade-routes/single/Form.tsx
+++ b/app/_components/trade-routes/single/Form.tsx
@@ -93,7 +93,6 @@ const Form: React.FC<FormProps> = ({
       buySystemName: data.buySystemName,
       sellSystemName: data.sellSystemName,
     };
-    console.log('submitting form data: ', data);
     onSubmitHandler(submitData);
   };
 

--- a/app/_components/trade-routes/single/Form.tsx
+++ b/app/_components/trade-routes/single/Form.tsx
@@ -9,28 +9,23 @@ import {
   GridItem,
   Input,
   FormErrorMessage,
-  Checkbox,
 } from '@chakra-ui/react';
 import { z } from 'zod';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { useForm, SubmitHandler } from 'react-hook-form';
 import GetColor from '@/app/_hooks/colorSelector';
 import {
-  PowersField,
-  AllegiancesField,
-  GovernmentsField,
   LandingPadsField,
   StationTypesField,
   CommoditiesField,
   SystemsField,
 } from '@/app/_components/inputs';
-import CheckboxGroup from '../../form/CheckboxGroup';
 import { useState } from 'react';
 import Select from '../../inputs/form/Select';
 import { ICommodity } from '@/app/_types';
 
 export const SingleTradeRouteFormSchema = z.object({
-  buySystem: z.object({ value: z.number() }).optional(),
+  targetSystem: z.object({ value: z.number() }).optional(),
   buyStation: z.string().optional(),
   sellSystem: z.object({ value: z.number() }).optional(),
   sellStation: z.string().optional(),
@@ -89,8 +84,7 @@ const Form: React.FC<FormProps> = ({
   };
 
   // For demo purposes
-  const [buySystemStations, setBuySystemStations] = useState<string[]>([]);
-  const [sellSystemStations, setSellSystemStations] = useState<string[]>([]);
+  const [buySystemStations, setTargetSystemStations] = useState<string[]>([]);
 
   return (
     <form onSubmit={handleSubmit(onSubmit)}>
@@ -105,21 +99,21 @@ const Form: React.FC<FormProps> = ({
       >
         <GridItem colSpan={{ base: 1, md: 2 }}>
           <FormControl
-            isInvalid={!!(errors.buySystem && errors.buySystem.message)}
+            isInvalid={!!(errors.targetSystem && errors.targetSystem.message)}
           >
-            <FormLabel>Buy from System</FormLabel>
+            <FormLabel>Target System</FormLabel>
             <SystemsField
-              fieldName="buySystem"
+              fieldName="targetSystem"
               control={control}
               placeholder="Select a system..."
               onChange={(newValue) => {
-                setBuySystemStations(
+                setTargetSystemStations(
                   newValue ? ['Station1', 'Station2', 'Station3'] : [],
                 );
               }}
             />
             <FormErrorMessage>
-              {errors.buySystem && errors.buySystem.message}
+              {errors.targetSystem && errors.targetSystem.message}
             </FormErrorMessage>
           </FormControl>
         </GridItem>
@@ -148,55 +142,6 @@ const Form: React.FC<FormProps> = ({
             </Select>
             <FormErrorMessage>
               {errors.buyStation && errors.buyStation.message}
-            </FormErrorMessage>
-          </FormControl>
-        </GridItem>
-
-        <GridItem colSpan={{ base: 1, md: 2 }}>
-          <FormControl
-            isInvalid={!!(errors.sellSystem && errors.sellSystem.message)}
-          >
-            <FormLabel>Sell to System</FormLabel>
-            <SystemsField
-              fieldName="sellSystem"
-              control={control}
-              placeholder="Select a system..."
-              onChange={(newValue) => {
-                setSellSystemStations(
-                  newValue ? ['Station1', 'Station2', 'Station3'] : [],
-                );
-              }}
-            />
-            <FormErrorMessage>
-              {errors.sellSystem && errors.sellSystem.message}
-            </FormErrorMessage>
-          </FormControl>
-        </GridItem>
-
-        <GridItem colSpan={{ base: 1, md: 2 }}>
-          <FormControl
-            isInvalid={!!(errors.sellStation && errors.sellStation.message)}
-          >
-            <FormLabel>Sell to Station</FormLabel>
-            <Select
-              register={register('sellStation', {
-                disabled: sellSystemStations.length === 0,
-              })}
-              placeholder={
-                sellSystemStations.length === 0
-                  ? 'Enter a system first...'
-                  : 'Select a station (optional)'
-              }
-            >
-              {sellSystemStations.length &&
-                sellSystemStations.map((station) => (
-                  <option key={station} value={station}>
-                    {station}
-                  </option>
-                ))}
-            </Select>
-            <FormErrorMessage>
-              {errors.sellStation && errors.sellStation.message}
             </FormErrorMessage>
           </FormControl>
         </GridItem>
@@ -361,30 +306,6 @@ const Form: React.FC<FormProps> = ({
 
         <GridItem>
           <FormControl
-            isInvalid={!!(errors.government && errors.government.message)}
-          >
-            <FormLabel>Government</FormLabel>
-            <GovernmentsField register={register('government')} />
-            <FormErrorMessage>
-              {errors.government && errors.government.message}
-            </FormErrorMessage>
-          </FormControl>
-        </GridItem>
-
-        <GridItem>
-          <FormControl
-            isInvalid={!!(errors.allegiance && errors.allegiance.message)}
-          >
-            <FormLabel>Allegiance</FormLabel>
-            <AllegiancesField register={register('allegiance')} />
-            <FormErrorMessage>
-              {errors.allegiance && errors.allegiance.message}
-            </FormErrorMessage>
-          </FormControl>
-        </GridItem>
-
-        <GridItem>
-          <FormControl
             isInvalid={
               !!(
                 errors.maxDistanceToArrival &&
@@ -410,16 +331,6 @@ const Form: React.FC<FormProps> = ({
           </FormControl>
         </GridItem>
 
-        <GridItem>
-          <FormControl isInvalid={!!(errors.power && errors.power.message)}>
-            <FormLabel>Powers</FormLabel>
-            <PowersField register={register('power')} />
-            <FormErrorMessage>
-              {errors.power && errors.power.message}
-            </FormErrorMessage>
-          </FormControl>
-        </GridItem>
-
         <GridItem colSpan={{ base: 1, md: 2 }}>
           <FormControl>
             <FormLabel>Station Type</FormLabel>
@@ -438,30 +349,6 @@ const Form: React.FC<FormProps> = ({
             <FormErrorMessage>
               {errors.landingPadSize && errors.landingPadSize.message}
             </FormErrorMessage>
-          </FormControl>
-        </GridItem>
-
-        <GridItem>
-          <FormControl>
-            <FormLabel>Other Options</FormLabel>
-            <CheckboxGroup>
-              <FormControl
-                isInvalid={
-                  !!(errors.requiresPermit && errors.requiresPermit.message)
-                }
-              >
-                <Checkbox
-                  colorScheme="orange"
-                  {...register('requiresPermit')}
-                  borderColor={GetColor('border')}
-                >
-                  Requires Permit
-                </Checkbox>
-                <FormErrorMessage>
-                  {errors.requiresPermit && errors.requiresPermit.message}
-                </FormErrorMessage>
-              </FormControl>
-            </CheckboxGroup>
           </FormControl>
         </GridItem>
       </Grid>

--- a/app/_components/trade-routes/single/Form.tsx
+++ b/app/_components/trade-routes/single/Form.tsx
@@ -326,12 +326,6 @@ const Form: React.FC<FormProps> = ({
           </FormControl>
         </GridItem>
 
-        <GridItem marginTop={30} colSpan={{ base: 1, md: 2, lg: 4 }}>
-          <h2>
-            <b>Station options:</b>
-          </h2>
-        </GridItem>
-
         <GridItem>
           <FormControl
             isInvalid={

--- a/app/_components/trade-routes/single/Form.tsx
+++ b/app/_components/trade-routes/single/Form.tsx
@@ -40,10 +40,7 @@ export const SingleTradeRouteFormSchema = z.object({
     .string()
     .optional()
     .transform((val) => Number(val)),
-  maxPriceAgeHours: z
-    .string()
-    .optional()
-    .transform((val) => Number(val)),
+  maxPriceAgeHours: z.number().optional(),
   cargoCapacity: z
     .string()
     .optional()
@@ -88,12 +85,7 @@ const Form: React.FC<FormProps> = ({
   });
 
   const onSubmit: SubmitHandler<SubmitProps> = (data) => {
-    const submitData = {
-      ...data,
-      buySystemName: data.buySystemName,
-      sellSystemName: data.sellSystemName,
-    };
-    onSubmitHandler(submitData);
+    onSubmitHandler(data);
   };
 
   // For demo purposes

--- a/app/_components/trade-routes/single/Form.tsx
+++ b/app/_components/trade-routes/single/Form.tsx
@@ -32,7 +32,10 @@ export const SingleTradeRouteFormSchema = z.object({
     .optional()
     .transform((val) => val?.label),
   sellStationName: z.string().optional(),
-  commodityDisplayNames: z.array(z.object({ value: z.string() })).optional(),
+  commodityDisplayName: z
+    .array(z.object({ value: z.string() }))
+    .optional()
+    .transform((val) => val?.map((v) => v.value)),
   maxRouteDistance: z
     .string()
     .optional()
@@ -90,7 +93,7 @@ const Form: React.FC<FormProps> = ({
       buySystemName: data.buySystemName,
       sellSystemName: data.sellSystemName,
     };
-    console.log('submitting form data: ', submitData);
+    console.log('submitting form data: ', data);
     onSubmitHandler(submitData);
   };
 
@@ -223,8 +226,8 @@ const Form: React.FC<FormProps> = ({
           <FormControl
             isInvalid={
               !!(
-                errors.commodityDisplayNames &&
-                errors.commodityDisplayNames.message
+                errors.commodityDisplayName &&
+                errors.commodityDisplayName.message
               )
             }
           >

--- a/app/_components/trade-routes/single/Form.tsx
+++ b/app/_components/trade-routes/single/Form.tsx
@@ -313,10 +313,10 @@ const Form: React.FC<FormProps> = ({
           >
             <FormLabel>Max Price Age</FormLabel>
             <Select register={register('maxPriceAgeHours')}>
-              <option value="12">12 hours</option>
-              <option value="24">1 day</option>
-              <option value="48">2 days</option>
-              <option value="72">3 days</option>
+              <option value={12}>12 hours</option>
+              <option value={24}>1 day</option>
+              <option value={48}>2 days</option>
+              <option value={72}>3 days</option>
             </Select>
             <FormErrorMessage>
               {errors.maxPriceAgeHours && errors.maxPriceAgeHours.message}

--- a/app/_types/forms.ts
+++ b/app/_types/forms.ts
@@ -27,8 +27,8 @@ export type TradeRouteFilters = {
   minSupply?: string;
   minDemand?: string;
   maxPriceAge?: string;
-  cargoCapacity?: string;
-  availableCredits?: string;
+  cargoCapacity?: number;
+  availableCredits?: number;
 
   government?: string;
   allegiance?: string;

--- a/app/_types/forms.ts
+++ b/app/_types/forms.ts
@@ -26,7 +26,7 @@ export type TradeRouteFilters = {
   maxHopDistance?: string;
   minSupply?: string;
   minDemand?: string;
-  maxPriceAge?: string;
+  maxPriceAge?: number;
   cargoCapacity?: number;
   availableCredits?: number;
 

--- a/app/_types/forms.ts
+++ b/app/_types/forms.ts
@@ -13,9 +13,9 @@ export type SingleTradeRouteForm = TradeRouteFilters & {
 };
 
 export type MultiTradeRouteForm = TradeRouteFilters & {
-  startSystem?: { value: number };
+  startSystem?: string;
   startStation?: string;
-  finishSystem?: { value: number };
+  finishSystem?: string;
   maxHopCount?: string;
 };
 

--- a/app/_types/system.ts
+++ b/app/_types/system.ts
@@ -21,5 +21,5 @@ export interface ISystem {
     z: number;
   };
   eliteId: number;
-  starClass: string;
+  primaryStarClass: string;
 }

--- a/mock/exploration.js
+++ b/mock/exploration.js
@@ -1,37 +1,37 @@
 module.exports = {
   'exploration-stations-by-name-containing': [
-    { name: "Daedalus" },
-    { name: "Ehrlich City" },
-    { name: "Abraham Lincoln" },
-    { name: "Mars High" },
-    { name: "Titan City" },
+    { name: 'Daedalus' },
+    { name: 'Ehrlich City' },
+    { name: 'Abraham Lincoln' },
+    { name: 'Mars High' },
+    { name: 'Titan City' },
     { name: "Dekker's Yard" },
-    { name: "Durrance Camp" }
+    { name: 'Durrance Camp' },
   ],
   'exploration-system-by-name-containing': [
     {
       name: 'Sol',
-      coordinates: { x: 1, y: 2, z: 1 },
+      coordinate: { x: 1, y: 2, z: 1 },
       eliteId: 1,
-      starClass: 'k',
+      primaryStarClass: 'k',
     },
     {
       name: 'Barnards Star',
       coordinates: { x: 1, y: 2, z: 1 },
       eliteId: 2,
-      starClass: 'k',
+      primaryStarClass: 'k',
     },
     {
       name: 'Alpha Centauri',
       coordinates: { x: 1, y: 2, z: 1 },
       eliteId: 3,
-      starClass: 'k',
+      primaryStarClass: 'k',
     },
     {
       name: 'Wolf 359',
       coordinates: { x: 1, y: 2, z: 1 },
       eliteId: 4,
-      starClass: 'k',
+      primaryStarClass: 'k',
     },
   ],
 };

--- a/next.config.js
+++ b/next.config.js
@@ -14,7 +14,7 @@ const nextConfig = {
     return [
       {
         source: '/api/:path*',
-        destination: 'http://morris.edpn.io:8080/api/:path*',
+        destination: 'http://duval.edpn.io:8080/api/:path*',
       },
     ];
   },


### PR DESCRIPTION
The primary objective here is to integrate the system search API endpoint with the single trade route finder route.

A few minor updates include:

- update staging API url for the entire app
- adjust submit types and values in the single trade route finder form to better reflect the desired params for the upcoming API endpoint
- remove unnecessary form inputs in the single trade route finder form

I initially planned to get this route completed, but the API endpoint for the form submission isn't finished. So I'd like to get what progress I've done merged in, and move on to other items.

NOTE: The system search API endpoint works here when running the app in PRODUCTION mode. You can run `yarn start && yarn build` to check it out. Station lookup endpoint is not finished, so there's still just a few canned selections for that input.