### PR TITLE
add station API calls to trade/single form

### DIFF
--- a/app/_components/inputs/Systems.tsx
+++ b/app/_components/inputs/Systems.tsx
@@ -29,26 +29,6 @@ type FieldOptions = {
   isMulti?: true;
 };
 
-/* Swap out for live lookup when data is available? */
-const getMockSystemName = async (lookupString: string) => {
-  const res = await fetch(
-    `${process.env.NEXT_PUBLIC_MOCK_API_URL}/api/v1/exploration/system/by-name-containing`,
-    {
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-      },
-      body: JSON.stringify({ name: lookupString }),
-    },
-  );
-
-  if (!res.ok) {
-    throw new Error(`HTTP error! status: ${res.status}`);
-  }
-
-  return res.json();
-};
-
 const getSystemName = async (lookupString: string) => {
   const res = await fetch(
     `${process.env.NEXT_PUBLIC_STAGING_API_URL}/api/v1/exploration/system/by-name-containing?subString=${lookupString}&amount=10`,
@@ -69,11 +49,7 @@ const loadOptions = async (inputValue: string): Promise<SelectGroup[] | []> => {
   try {
     let res = [];
 
-    if (process.env.NODE_ENV === 'development') {
-      res = await getMockSystemName(inputValue);
-    } else {
-      res = await getSystemName(inputValue);
-    }
+    res = await getSystemName(inputValue);
 
     const returnArr: SelectGroup[] = res.map((item: ISystem) => ({
       value: item.eliteId,

--- a/app/_components/inputs/form/ChakraReactSelect.tsx
+++ b/app/_components/inputs/form/ChakraReactSelect.tsx
@@ -1,0 +1,55 @@
+import { useEffect, useState } from 'react';
+import { Controller } from 'react-hook-form';
+import { Select as ChakraSelect } from 'chakra-react-select';
+import SelectStyles from '@/app/_hooks/SelectStyles';
+
+interface Props {
+  fieldName: string;
+  options: string[];
+  control: any;
+  placeholder: string;
+}
+
+// consumes an array of strings {options} and outputs a styled selection component with search functionality
+const ChakraReactSelect = ({
+  fieldName,
+  options,
+  control,
+  placeholder,
+}: Props) => {
+  const [optionsState, setOptionsState] = useState<
+    { label: string; value: string }[]
+  >([]);
+
+  const formatOptions = () =>
+    options.map((val) => ({
+      label: val,
+      value: val,
+    }));
+
+  useEffect(() => {
+    setOptionsState(formatOptions());
+  }, [options]);
+
+  return (
+    <Controller
+      control={control}
+      name={fieldName}
+      render={({ field: { onChange, onBlur, value, name, ref } }) => (
+        <ChakraSelect
+          isClearable
+          name={name}
+          ref={ref}
+          onChange={onChange}
+          onBlur={onBlur}
+          options={optionsState}
+          placeholder={placeholder}
+          value={value}
+          chakraStyles={SelectStyles()}
+        />
+      )}
+    />
+  );
+};
+
+export default ChakraReactSelect;

--- a/app/_components/trade-routes/single/Form.tsx
+++ b/app/_components/trade-routes/single/Form.tsx
@@ -24,12 +24,27 @@ import {
 import { ICommodity } from '@/app/_types';
 import ExpandIcon from '../../utility/ExpandIcon';
 import { useGetData } from '@/app/_lib/api-calls';
+import ChakraReactSelect from '../../inputs/form/ChakraReactSelect';
 
 export const SingleTradeRouteFormSchema = z.object({
-  buySystemName: z.object({ label: z.string(), value: z.number() }).optional(),
-  buyStationName: z.string().optional(),
-  sellSystemName: z.object({ label: z.string(), value: z.number() }).optional(),
-  sellStationName: z.string().optional(),
+  buySystemName: z
+    .object({ label: z.string(), value: z.number() })
+    .optional()
+    .nullable(),
+  buyStationName: z
+    .object({ label: z.string(), value: z.string() })
+    .optional()
+    .nullable()
+    .transform((val) => val?.value),
+  sellSystemName: z
+    .object({ label: z.string(), value: z.number() })
+    .optional()
+    .nullable(),
+  sellStationName: z
+    .object({ label: z.string(), value: z.string() })
+    .optional()
+    .nullable()
+    .transform((val) => val?.value),
   commodityDisplayName: z
     .array(z.object({ value: z.string() }))
     .optional()
@@ -72,7 +87,6 @@ const Form: React.FC<FormProps> = ({
 }) => {
   const [isExpanded, setIsExpanded] = useState(false);
 
-  // For demo purposes
   const [buySystemStations, setBuySystemStations] = useState<string[]>([]);
   const [sellSystemStations, setSellSystemStations] = useState<string[]>([]);
 
@@ -163,23 +177,16 @@ const Form: React.FC<FormProps> = ({
             }
           >
             <FormLabel>Buy from Station</FormLabel>
-            <Select
-              register={register('buyStationName', {
-                disabled: buySystemStations.length === 0,
-              })}
+            <ChakraReactSelect
+              fieldName="buyStationName"
+              options={buySystemStations}
+              control={control}
               placeholder={
                 buySystemStations.length === 0
                   ? 'Enter a system first...'
                   : 'Select a station (optional)'
               }
-            >
-              {buySystemStations.length &&
-                buySystemStations.map((station) => (
-                  <option key={station} value={station}>
-                    {station}
-                  </option>
-                ))}
-            </Select>
+            />
             <FormErrorMessage>
               {errors.buyStationName && errors.buyStationName.message}
             </FormErrorMessage>
@@ -211,23 +218,16 @@ const Form: React.FC<FormProps> = ({
             }
           >
             <FormLabel>Sell to Station</FormLabel>
-            <Select
-              register={register('sellStationName', {
-                disabled: sellSystemStations.length === 0,
-              })}
+            <ChakraReactSelect
+              fieldName="sellStationName"
+              options={sellSystemStations}
+              control={control}
               placeholder={
                 sellSystemStations.length === 0
                   ? 'Enter a system first...'
                   : 'Select a station (optional)'
               }
-            >
-              {sellSystemStations.length &&
-                sellSystemStations.map((station) => (
-                  <option key={station} value={station}>
-                    {station}
-                  </option>
-                ))}
-            </Select>
+            />
             <FormErrorMessage>
               {errors.sellStationName && errors.sellStationName.message}
             </FormErrorMessage>

--- a/app/_lib/api-calls.tsx
+++ b/app/_lib/api-calls.tsx
@@ -67,8 +67,29 @@ const useGetMockSubmitFormClient = (queryString: string) => {
   };
 };
 
+// typical request fetching data from staging URL
+const useGetData = (queryString: string) => {
+  const { data, error, isLoading, mutate } = useSWR(
+    `${process.env.NEXT_PUBLIC_STAGING_API_URL}/api/v1/${queryString}`,
+    fetcher,
+    {
+      shouldRetryOnError: false,
+      revalidateOnFocus: false,
+      revalidateOnMount: false,
+    },
+  );
+
+  return {
+    data,
+    isLoading,
+    error,
+    mutate,
+  };
+};
+
 export {
   getFormElementDataServer,
   useGetSubmitFormClient,
   useGetMockSubmitFormClient,
+  useGetData,
 };

--- a/app/trade/single/page.client.tsx
+++ b/app/trade/single/page.client.tsx
@@ -22,7 +22,7 @@ const PageClient = ({ commodities }: IPageClientProps) => {
       ...data,
     };
 
-    // TODO: submit data to backend
+    // TODO: format and submit data to backend
     setTimeout(() => {
       console.log('submitted ', submitData);
       setIsLoading(false);


### PR DESCRIPTION
now when a user selects a system in the [single-route trade form](https://oscar.edpn.io/trade/single) the following occurs:

1. a GET call is made to the API to fetch any known stations in the selected system
2. the result populates a select input in the form where the user can choose a desired station 