### PR TITLE
Fix price age select placeholder, max value, and landing pad size nullability

### DIFF
--- a/app/_components/inputs/form/Select.tsx
+++ b/app/_components/inputs/form/Select.tsx
@@ -2,15 +2,28 @@ import { Select as ChakraSelect } from '@chakra-ui/react';
 import { ReactNode } from 'react';
 import { UseFormRegisterReturn } from 'react-hook-form';
 
+type DefaultEnum = string | number;
+
 interface Props {
   children: ReactNode;
+  defaultValue: DefaultEnum;
   register?: UseFormRegisterReturn;
   placeholder?: string;
   disabled?: boolean;
 }
 
-const Select = ({ children, register, placeholder = 'Select...' }: Props) => (
-  <ChakraSelect {...register} placeholder={placeholder} variant="outline">
+const Select = ({
+  children,
+  defaultValue,
+  register,
+  placeholder = 'Select...',
+}: Props) => (
+  <ChakraSelect
+    defaultValue={defaultValue}
+    {...register}
+    placeholder={placeholder}
+    variant="outline"
+  >
     {children}
   </ChakraSelect>
 );

--- a/app/_components/inputs/form/Select.tsx
+++ b/app/_components/inputs/form/Select.tsx
@@ -6,7 +6,7 @@ type DefaultEnum = string | number;
 
 interface Props {
   children: ReactNode;
-  defaultValue: DefaultEnum;
+  defaultValue?: DefaultEnum;
   register?: UseFormRegisterReturn;
   placeholder?: string;
   disabled?: boolean;
@@ -14,8 +14,8 @@ interface Props {
 
 const Select = ({
   children,
-  defaultValue,
   register,
+  defaultValue,
   placeholder = 'Select...',
 }: Props) => (
   <ChakraSelect

--- a/app/_components/trade-routes/single/Form.tsx
+++ b/app/_components/trade-routes/single/Form.tsx
@@ -54,9 +54,9 @@ export const SingleTradeRouteFormSchema = z.object({
     .optional()
     .transform((val) => Number(val)),
   maxPriceAgeHours: z
-    .number()
+    .string()
     .optional()
-    .transform((val) => val || 72),
+    .transform((val) => Number(val) || 72),
   cargoCapacity: z
     .string()
     .optional()
@@ -65,7 +65,7 @@ export const SingleTradeRouteFormSchema = z.object({
     .string()
     .optional()
     .transform((val) => Number(val)),
-  maxLandingPadSize: z.string().optional().nullable(),
+  maxLandingPadSize: z.string().optional(),
   maxArrivalDistance: z
     .string()
     .optional()
@@ -361,9 +361,7 @@ const Form: React.FC<FormProps> = ({
               }
             >
               <FormLabel>Max Price Age</FormLabel>
-              <Select
-                register={register('maxPriceAgeHours', { valueAsNumber: true })}
-              >
+              <Select register={register('maxPriceAgeHours')} defaultValue={72}>
                 <option value={12}>12 hours</option>
                 <option value={24}>1 day</option>
                 <option value={48}>2 days</option>

--- a/app/_components/trade-routes/single/Form.tsx
+++ b/app/_components/trade-routes/single/Form.tsx
@@ -53,7 +53,10 @@ export const SingleTradeRouteFormSchema = z.object({
     .string()
     .optional()
     .transform((val) => Number(val)),
-  maxPriceAgeHours: z.number().optional(),
+  maxPriceAgeHours: z
+    .number()
+    .optional()
+    .transform((val) => val || 72),
   cargoCapacity: z
     .string()
     .optional()
@@ -62,7 +65,7 @@ export const SingleTradeRouteFormSchema = z.object({
     .string()
     .optional()
     .transform((val) => Number(val)),
-  maxLandingPadSize: z.string().optional(),
+  maxLandingPadSize: z.string().optional().nullable(),
   maxArrivalDistance: z
     .string()
     .optional()
@@ -97,9 +100,7 @@ const Form: React.FC<FormProps> = ({
     watch,
     formState: { errors },
   } = useForm<SubmitProps>({
-    defaultValues: {
-      maxPriceAgeHours: 72,
-    },
+    defaultValues: {},
     resolver: zodResolver(SingleTradeRouteFormSchema),
   });
   const buySystem = watch('buySystemName', { value: 0, label: '' });


### PR DESCRIPTION
This fixes the following issues:
- #142 
- The placeholder for the price age selector not being the default
- The landing pad size throwing an error when no option is selected

Of note is that the default for the price age selector remains at 72, which is not obvious, however I think it makes sense for this anyway because if you don't care about the maximum, then the highest possible maximum is what you want, to encompass all possible values.

Internally, I would prefer to set the default to `Infinity` since this means that if we ever added higher max ages, the default would not need to be changed, however I'm not sure how sending `Infinity` over http is handled and whether the backend would be happy with it.