### PR TITLE
prepare trade/single form submit for response

### DIFF
--- a/.env
+++ b/.env
@@ -1,3 +1,3 @@
 NEXT_PUBLIC_STAGE=localhost
 NEXT_PUBLIC_MOCK_API_URL=http://localhost:3001
-NEXT_PUBLIC_STAGING_API_URL=http://duval.edpn.io:8080
+NEXT_PUBLIC_STAGING_API_URL=https://duval.edpn.io

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -16,6 +16,7 @@
     "prettier/prettier": "error",
     "prefer-const": "off",
     "no-use-before-define": "off",
+    "react/no-unescaped-entities": "off",
     "react/react-in-jsx-scope": "off",
     "import/order": "off",
     "space-before-function-paren": [

--- a/app/_components/inputs/Commodities.tsx
+++ b/app/_components/inputs/Commodities.tsx
@@ -51,13 +51,13 @@ const CommoditiesField: React.FC<CommodityProps> = ({
 
   return (
     <Controller
-      name="commodityDisplayName"
+      name="commodityDisplayNames"
       control={control}
       rules={{ required: 'Enter at least one commodity' }}
       render={({ field: { onChange, onBlur, value, name, ref } }) => (
         <Select<CommoditySelectItems, true, GroupBase<CommoditySelectItems>>
-          id="commodityDisplayName"
-          instanceId="commodityDisplayName"
+          id="commodityDisplayNames"
+          instanceId="commodityDisplayNames"
           name={name}
           ref={ref}
           onInputChange={(input) => {

--- a/app/_components/inputs/StationTypes.tsx
+++ b/app/_components/inputs/StationTypes.tsx
@@ -8,7 +8,7 @@ interface Props {
 
 export const checkboxValues = [
   { name: 'Orbital', value: 'includeOrbital', checked: true },
-  { name: 'Planetary', value: 'includePlanetary' },
+  { name: 'Planetary', value: 'includeSurfaceStations' },
   { name: 'Odyssey', value: 'includeOdyssey' },
   { name: 'Carriers', value: 'includeFleetCarriers' },
 ];

--- a/app/_components/inputs/tests/Commodities.test.tsx
+++ b/app/_components/inputs/tests/Commodities.test.tsx
@@ -92,7 +92,7 @@ describe('Commodities Field', () => {
 
     // Check item is selected
     expect(getByTestId('form')).toHaveFormValues({
-      commodityDisplayName: 'Trillium',
+      commodityDisplayNames: 'Trillium',
     });
 
     act(() => {
@@ -106,7 +106,7 @@ describe('Commodities Field', () => {
 
     // Check both items are selected
     expect(getByTestId('form')).toHaveFormValues({
-      commodityDisplayName: 'Gold',
+      commodityDisplayNames: 'Gold',
     });
   });
 
@@ -135,7 +135,7 @@ describe('Commodities Field', () => {
 
     // Check item is selected
     expect(getByTestId('form')).toHaveFormValues({
-      commodityDisplayName: 'Trillium',
+      commodityDisplayNames: 'Trillium',
     });
 
     act(() => {
@@ -149,7 +149,7 @@ describe('Commodities Field', () => {
 
     // Check both items are selected
     expect(getByTestId('form')).toHaveFormValues({
-      commodityDisplayName: ['Trillium', 'Gold'],
+      commodityDisplayNames: ['Trillium', 'Gold'],
     });
   });
 });

--- a/app/_components/trade-routes/single/Form.test.tsx
+++ b/app/_components/trade-routes/single/Form.test.tsx
@@ -66,7 +66,7 @@ describe('Stations Form', () => {
     ).toBeInTheDocument();
 
     expect(
-      screen.getByRole('spinbutton', { name: 'Max Route Distance - LY' }),
+      screen.getByRole('spinbutton', { name: 'Max Route Distance' }),
     ).toBeInTheDocument();
 
     expect(
@@ -82,7 +82,7 @@ describe('Stations Form', () => {
     ).toBeInTheDocument();
 
     expect(
-      screen.getByRole('spinbutton', { name: 'Max Distance From Star - LS' }),
+      screen.getByRole('spinbutton', { name: 'Max Distance From Star' }),
     ).toBeInTheDocument();
 
     /* Mocked abstracted fields */

--- a/app/_components/trade-routes/single/Form.test.tsx
+++ b/app/_components/trade-routes/single/Form.test.tsx
@@ -66,7 +66,7 @@ describe('Stations Form', () => {
     ).toBeInTheDocument();
 
     expect(
-      screen.getByRole('spinbutton', { name: 'Max Route Distance' }),
+      screen.getByRole('spinbutton', { name: 'Max Route Distance - LY' }),
     ).toBeInTheDocument();
 
     expect(
@@ -82,7 +82,7 @@ describe('Stations Form', () => {
     ).toBeInTheDocument();
 
     expect(
-      screen.getByRole('spinbutton', { name: 'Max Distance From Star' }),
+      screen.getByRole('spinbutton', { name: 'Max Distance From Star - LS' }),
     ).toBeInTheDocument();
 
     /* Mocked abstracted fields */

--- a/app/_components/trade-routes/single/Form.tsx
+++ b/app/_components/trade-routes/single/Form.tsx
@@ -19,6 +19,8 @@ import {
   FormErrorMessage,
   HStack,
   Collapse,
+  InputGroup,
+  InputRightAddon,
 } from '@chakra-ui/react';
 import ExpandIcon from '../../utility/ExpandIcon';
 import { useGetData } from '@/app/_lib/api-calls';
@@ -203,16 +205,22 @@ const Form: React.FC<FormProps> = ({
               !!(errors.maxRouteDistance && errors.maxRouteDistance.message)
             }
           >
-            <FormLabel>Max Route Distance - LY</FormLabel>
-            <Input
-              type="number"
-              variant="outline"
-              borderColor={GetColor('border')}
-              _hover={{
-                borderColor: GetColor('border'),
-              }}
-              {...register('maxRouteDistance', { valueAsNumber: true })}
-            />
+            <FormLabel>Max Route Distance</FormLabel>
+            <InputGroup>
+              <Input
+                type="number"
+                variant="outline"
+                borderColor={GetColor('border')}
+                borderRight={0}
+                _hover={{
+                  borderColor: GetColor('border'),
+                }}
+                {...register('maxRouteDistance', { valueAsNumber: true })}
+              />
+              <InputRightAddon borderColor={GetColor('border')} borderLeft={0}>
+                LY
+              </InputRightAddon>
+            </InputGroup>
             <FormErrorMessage>
               {errors.maxRouteDistance && errors.maxRouteDistance.message}
             </FormErrorMessage>
@@ -340,16 +348,25 @@ const Form: React.FC<FormProps> = ({
                 )
               }
             >
-              <FormLabel>Max Distance From Star - LS</FormLabel>
-              <Input
-                type="number"
-                variant="outline"
-                borderColor={GetColor('border')}
-                _hover={{
-                  borderColor: GetColor('border'),
-                }}
-                {...register('maxArrivalDistance', { valueAsNumber: true })}
-              />
+              <FormLabel>Max Distance From Star</FormLabel>
+              <InputGroup>
+                <Input
+                  type="number"
+                  variant="outline"
+                  borderColor={GetColor('border')}
+                  borderRight={0}
+                  _hover={{
+                    borderColor: GetColor('border'),
+                  }}
+                  {...register('maxArrivalDistance', { valueAsNumber: true })}
+                />
+                <InputRightAddon
+                  borderColor={GetColor('border')}
+                  borderLeft={0}
+                >
+                  LS
+                </InputRightAddon>
+              </InputGroup>
               <FormErrorMessage>
                 {errors.maxArrivalDistance && errors.maxArrivalDistance.message}
               </FormErrorMessage>

--- a/app/_components/trade-routes/single/Form.tsx
+++ b/app/_components/trade-routes/single/Form.tsx
@@ -20,11 +20,11 @@ import {
   HStack,
   Collapse,
 } from '@chakra-ui/react';
-import { ICommodity } from '@/app/_types';
 import ExpandIcon from '../../utility/ExpandIcon';
 import { useGetData } from '@/app/_lib/api-calls';
 import ChakraReactSelect from '../../inputs/form/ChakraReactSelect';
 import { FormSubmitProps, FormSubmitSchema } from './Schema';
+import { ICommodity } from '@/app/_types';
 
 interface FormProps {
   onSubmitHandler: SubmitHandler<FormSubmitProps>;
@@ -62,13 +62,13 @@ const Form: React.FC<FormProps> = ({
   const buySystem = watch('buyFromSystemName', { value: 0, label: '' });
   const sellSystem = watch('sellToSystemName', { value: 0, label: '' });
 
-  const { data: buyStationData, mutate: buyStationMutate } = useGetData(
-    `exploration/system/list-station-names?systemName=${buySystem?.label}`,
-  );
+  const { data: buyStationData, mutate: buyStationMutate } = useGetData<
+    string[]
+  >(`exploration/system/list-station-names?systemName=${buySystem?.label}`);
 
-  const { data: sellStationData, mutate: sellStationMutate } = useGetData(
-    `exploration/system/list-station-names?systemName=${sellSystem?.label}`,
-  );
+  const { data: sellStationData, mutate: sellStationMutate } = useGetData<
+    string[]
+  >(`exploration/system/list-station-names?systemName=${sellSystem?.label}`);
 
   useEffect(() => {
     const systemName = buySystem?.label;

--- a/app/_components/trade-routes/single/Form.tsx
+++ b/app/_components/trade-routes/single/Form.tsx
@@ -24,10 +24,10 @@ import { ICommodity } from '@/app/_types';
 import ExpandIcon from '../../utility/ExpandIcon';
 import { useGetData } from '@/app/_lib/api-calls';
 import ChakraReactSelect from '../../inputs/form/ChakraReactSelect';
-import { SingleTradeRouteFormSchema, SubmitProps } from './Schema';
+import { FormSubmitProps, FormSubmitSchema } from './Schema';
 
 interface FormProps {
-  onSubmitHandler: SubmitHandler<SubmitProps>;
+  onSubmitHandler: SubmitHandler<FormSubmitProps>;
   isLoading: boolean;
   commodities: ICommodity[] | null;
 }
@@ -48,9 +48,16 @@ const Form: React.FC<FormProps> = ({
     handleSubmit,
     watch,
     formState: { errors },
-  } = useForm<SubmitProps>({
-    defaultValues: {},
-    resolver: zodResolver(SingleTradeRouteFormSchema),
+  } = useForm<FormSubmitProps>({
+    defaultValues: {
+      cargoCapacity: 500,
+      maxRouteDistance: 100,
+      maxArrivalDistance: 1000,
+      includeOdyssey: false,
+      includeSurfaceStations: false,
+      includeFleetCarriers: false,
+    },
+    resolver: zodResolver(FormSubmitSchema),
   });
   const buySystem = watch('buyFromSystemName', { value: 0, label: '' });
   const sellSystem = watch('sellToSystemName', { value: 0, label: '' });
@@ -89,7 +96,7 @@ const Form: React.FC<FormProps> = ({
     if (sellStationData) setSellSystemStations(sellStationData);
   }, [sellStationData]);
 
-  const onSubmit: SubmitHandler<SubmitProps> = (data) => {
+  const onSubmit: SubmitHandler<FormSubmitProps> = (data) => {
     onSubmitHandler(data);
   };
 
@@ -196,19 +203,39 @@ const Form: React.FC<FormProps> = ({
               !!(errors.maxRouteDistance && errors.maxRouteDistance.message)
             }
           >
-            <FormLabel>Max Route Distance</FormLabel>
+            <FormLabel>Max Route Distance - LY</FormLabel>
             <Input
               type="number"
               variant="outline"
-              placeholder="in LY"
               borderColor={GetColor('border')}
               _hover={{
                 borderColor: GetColor('border'),
               }}
-              {...register('maxRouteDistance')}
+              {...register('maxRouteDistance', { valueAsNumber: true })}
             />
             <FormErrorMessage>
               {errors.maxRouteDistance && errors.maxRouteDistance.message}
+            </FormErrorMessage>
+          </FormControl>
+        </GridItem>
+
+        <GridItem>
+          <FormControl
+            isInvalid={!!(errors.cargoCapacity && errors.cargoCapacity.message)}
+          >
+            <FormLabel>Cargo Capacity</FormLabel>
+            <Input
+              type="number"
+              variant="outline"
+              placeholder="Enter a number..."
+              borderColor={GetColor('border')}
+              _hover={{
+                borderColor: GetColor('border'),
+              }}
+              {...register('cargoCapacity', { valueAsNumber: true })}
+            />
+            <FormErrorMessage>
+              {errors.cargoCapacity && errors.cargoCapacity.message}
             </FormErrorMessage>
           </FormControl>
         </GridItem>
@@ -266,29 +293,6 @@ const Form: React.FC<FormProps> = ({
           <GridItem>
             <FormControl
               isInvalid={
-                !!(errors.cargoCapacity && errors.cargoCapacity.message)
-              }
-            >
-              <FormLabel>Cargo Capacity</FormLabel>
-              <Input
-                type="number"
-                variant="outline"
-                placeholder="Enter a number..."
-                borderColor={GetColor('border')}
-                _hover={{
-                  borderColor: GetColor('border'),
-                }}
-                {...register('cargoCapacity')}
-              />
-              <FormErrorMessage>
-                {errors.cargoCapacity && errors.cargoCapacity.message}
-              </FormErrorMessage>
-            </FormControl>
-          </GridItem>
-
-          <GridItem>
-            <FormControl
-              isInvalid={
                 !!(errors.availableCredits && errors.availableCredits.message)
               }
             >
@@ -336,16 +340,15 @@ const Form: React.FC<FormProps> = ({
                 )
               }
             >
-              <FormLabel>Max Distance From Star</FormLabel>
+              <FormLabel>Max Distance From Star - LS</FormLabel>
               <Input
                 type="number"
                 variant="outline"
-                placeholder="In LS"
                 borderColor={GetColor('border')}
                 _hover={{
                   borderColor: GetColor('border'),
                 }}
-                {...register('maxArrivalDistance')}
+                {...register('maxArrivalDistance', { valueAsNumber: true })}
               />
               <FormErrorMessage>
                 {errors.maxArrivalDistance && errors.maxArrivalDistance.message}

--- a/app/_components/trade-routes/single/Form.tsx
+++ b/app/_components/trade-routes/single/Form.tsx
@@ -1,5 +1,4 @@
 import { useEffect, useState } from 'react';
-import { z } from 'zod';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { useForm, SubmitHandler } from 'react-hook-form';
 import GetColor from '@/app/_hooks/colorSelector';
@@ -25,57 +24,7 @@ import { ICommodity } from '@/app/_types';
 import ExpandIcon from '../../utility/ExpandIcon';
 import { useGetData } from '@/app/_lib/api-calls';
 import ChakraReactSelect from '../../inputs/form/ChakraReactSelect';
-
-export const SingleTradeRouteFormSchema = z.object({
-  buySystemName: z
-    .object({ label: z.string(), value: z.number() })
-    .optional()
-    .nullable(),
-  buyStationName: z
-    .object({ label: z.string(), value: z.string() })
-    .optional()
-    .nullable()
-    .transform((val) => val?.value),
-  sellSystemName: z
-    .object({ label: z.string(), value: z.number() })
-    .optional()
-    .nullable(),
-  sellStationName: z
-    .object({ label: z.string(), value: z.string() })
-    .optional()
-    .nullable()
-    .transform((val) => val?.value),
-  commodityDisplayName: z
-    .array(z.object({ value: z.string() }))
-    .optional()
-    .transform((val) => val?.map((v) => v.value)),
-  maxRouteDistance: z
-    .string()
-    .optional()
-    .transform((val) => Number(val)),
-  maxPriceAgeHours: z
-    .string()
-    .optional()
-    .transform((val) => Number(val) || 72),
-  cargoCapacity: z
-    .string()
-    .optional()
-    .transform((val) => Number(val)),
-  availableCredits: z
-    .string()
-    .optional()
-    .transform((val) => Number(val)),
-  maxLandingPadSize: z.string().optional(),
-  maxArrivalDistance: z
-    .string()
-    .optional()
-    .transform((val) => Number(val)),
-  includeFleetCarriers: z.boolean().optional(),
-  includeSurfaceStations: z.boolean().optional(),
-  includeOdyssey: z.boolean().optional(),
-});
-
-export type SubmitProps = z.infer<typeof SingleTradeRouteFormSchema>;
+import { SingleTradeRouteFormSchema, SubmitProps } from './Schema';
 
 interface FormProps {
   onSubmitHandler: SubmitHandler<SubmitProps>;
@@ -103,8 +52,8 @@ const Form: React.FC<FormProps> = ({
     defaultValues: {},
     resolver: zodResolver(SingleTradeRouteFormSchema),
   });
-  const buySystem = watch('buySystemName', { value: 0, label: '' });
-  const sellSystem = watch('sellSystemName', { value: 0, label: '' });
+  const buySystem = watch('buyFromSystemName', { value: 0, label: '' });
+  const sellSystem = watch('sellToSystemName', { value: 0, label: '' });
 
   const { data: buyStationData, mutate: buyStationMutate } = useGetData(
     `exploration/system/list-station-names?systemName=${buySystem?.label}`,
@@ -144,6 +93,10 @@ const Form: React.FC<FormProps> = ({
     onSubmitHandler(data);
   };
 
+  // TODO: cargoCapacity needs to be required and have a default
+  // same goes for maxRouteDistance and maxArrivalDistance
+  // will need to shuffle these inputs out of the collapse
+  // radio options need to return false if not selected
   return (
     <form onSubmit={handleSubmit(onSubmit)}>
       <Grid
@@ -157,16 +110,18 @@ const Form: React.FC<FormProps> = ({
       >
         <GridItem colSpan={{ base: 1, md: 2 }}>
           <FormControl
-            isInvalid={!!(errors.buySystemName && errors.buySystemName.message)}
+            isInvalid={
+              !!(errors.buyFromSystemName && errors.buyFromSystemName.message)
+            }
           >
             <FormLabel>Buy From System</FormLabel>
             <SystemsField
-              fieldName="buySystemName"
+              fieldName="buyFromSystemName"
               control={control}
               placeholder="Select a system..."
             />
             <FormErrorMessage>
-              {errors.buySystemName && errors.buySystemName.message}
+              {errors.buyFromSystemName && errors.buyFromSystemName.message}
             </FormErrorMessage>
           </FormControl>
         </GridItem>
@@ -174,12 +129,12 @@ const Form: React.FC<FormProps> = ({
         <GridItem colSpan={{ base: 1, md: 2 }}>
           <FormControl
             isInvalid={
-              !!(errors.buyStationName && errors.buyStationName.message)
+              !!(errors.buyFromStationName && errors.buyFromStationName.message)
             }
           >
             <FormLabel>Buy from Station</FormLabel>
             <ChakraReactSelect
-              fieldName="buyStationName"
+              fieldName="buyFromStationName"
               options={buySystemStations}
               control={control}
               placeholder={
@@ -189,7 +144,7 @@ const Form: React.FC<FormProps> = ({
               }
             />
             <FormErrorMessage>
-              {errors.buyStationName && errors.buyStationName.message}
+              {errors.buyFromStationName && errors.buyFromStationName.message}
             </FormErrorMessage>
           </FormControl>
         </GridItem>
@@ -197,17 +152,17 @@ const Form: React.FC<FormProps> = ({
         <GridItem colSpan={{ base: 1, md: 2 }}>
           <FormControl
             isInvalid={
-              !!(errors.sellSystemName && errors.sellSystemName.message)
+              !!(errors.sellToSystemName && errors.sellToSystemName.message)
             }
           >
             <FormLabel>Sell to System</FormLabel>
             <SystemsField
-              fieldName="sellSystemName"
+              fieldName="sellToSystemName"
               control={control}
               placeholder="Select a system..."
             />
             <FormErrorMessage>
-              {errors.sellSystemName && errors.sellSystemName.message}
+              {errors.sellToSystemName && errors.sellToSystemName.message}
             </FormErrorMessage>
           </FormControl>
         </GridItem>
@@ -215,12 +170,12 @@ const Form: React.FC<FormProps> = ({
         <GridItem colSpan={{ base: 1, md: 2 }}>
           <FormControl
             isInvalid={
-              !!(errors.sellStationName && errors.sellStationName.message)
+              !!(errors.sellToStationName && errors.sellToStationName.message)
             }
           >
             <FormLabel>Sell to Station</FormLabel>
             <ChakraReactSelect
-              fieldName="sellStationName"
+              fieldName="sellToStationName"
               options={sellSystemStations}
               control={control}
               placeholder={
@@ -230,7 +185,7 @@ const Form: React.FC<FormProps> = ({
               }
             />
             <FormErrorMessage>
-              {errors.sellStationName && errors.sellStationName.message}
+              {errors.sellToStationName && errors.sellToStationName.message}
             </FormErrorMessage>
           </FormControl>
         </GridItem>
@@ -293,8 +248,8 @@ const Form: React.FC<FormProps> = ({
             <FormControl
               isInvalid={
                 !!(
-                  errors.commodityDisplayName &&
-                  errors.commodityDisplayName.message
+                  errors.commodityDisplayNames &&
+                  errors.commodityDisplayNames.message
                 )
               }
             >

--- a/app/_components/trade-routes/single/Schema.ts
+++ b/app/_components/trade-routes/single/Schema.ts
@@ -1,0 +1,52 @@
+import { z } from 'zod';
+
+export const SingleTradeRouteFormSchema = z.object({
+  buyFromSystemName: z
+    .object({ label: z.string(), value: z.number() })
+    .optional()
+    .nullable(),
+  buyFromStationName: z
+    .object({ label: z.string(), value: z.string() })
+    .optional()
+    .nullable()
+    .transform((val) => val?.value),
+  sellToSystemName: z
+    .object({ label: z.string(), value: z.number() })
+    .optional()
+    .nullable(),
+  sellToStationName: z
+    .object({ label: z.string(), value: z.string() })
+    .optional()
+    .nullable()
+    .transform((val) => val?.value),
+  commodityDisplayNames: z
+    .array(z.object({ value: z.string() }))
+    .optional()
+    .transform((val) => val?.map((v) => v.value)),
+  maxRouteDistance: z
+    .string()
+    .optional()
+    .transform((val) => Number(val)),
+  maxPriceAgeHours: z
+    .string()
+    .optional()
+    .transform((val) => Number(val) || 72),
+  cargoCapacity: z
+    .string()
+    .optional()
+    .transform((val) => Number(val)),
+  availableCredits: z
+    .string()
+    .optional()
+    .transform((val) => Number(val)),
+  maxLandingPadSize: z.string().optional(),
+  maxArrivalDistance: z
+    .string()
+    .optional()
+    .transform((val) => Number(val)),
+  includeFleetCarriers: z.boolean().optional(),
+  includeSurfaceStations: z.boolean().optional(),
+  includeOdyssey: z.boolean().optional(),
+});
+
+export type SubmitProps = z.infer<typeof SingleTradeRouteFormSchema>;

--- a/app/_components/trade-routes/single/Schema.ts
+++ b/app/_components/trade-routes/single/Schema.ts
@@ -1,6 +1,7 @@
 import { z } from 'zod';
+import { ZodCommodityNameApiConst, ZodStationDtoApiConst } from '@/app/_types';
 
-export const SingleTradeRouteFormSchema = z.object({
+export const FormSubmitSchema = z.object({
   buyFromSystemName: z
     .object({ label: z.string(), value: z.number() })
     .optional()
@@ -23,30 +24,35 @@ export const SingleTradeRouteFormSchema = z.object({
     .array(z.object({ value: z.string() }))
     .optional()
     .transform((val) => val?.map((v) => v.value)),
-  maxRouteDistance: z
-    .string()
-    .optional()
-    .transform((val) => Number(val)),
+  maxRouteDistance: z.number(),
   maxPriceAgeHours: z
     .string()
     .optional()
     .transform((val) => Number(val) || 72),
-  cargoCapacity: z
-    .string()
-    .optional()
-    .transform((val) => Number(val)),
+  cargoCapacity: z.number(),
   availableCredits: z
     .string()
     .optional()
     .transform((val) => Number(val)),
   maxLandingPadSize: z.string().optional(),
-  maxArrivalDistance: z
-    .string()
-    .optional()
-    .transform((val) => Number(val)),
-  includeFleetCarriers: z.boolean().optional(),
-  includeSurfaceStations: z.boolean().optional(),
-  includeOdyssey: z.boolean().optional(),
+  maxArrivalDistance: z.number(),
+  includeFleetCarriers: z.boolean(),
+  includeSurfaceStations: z.boolean(),
+  includeOdyssey: z.boolean(),
 });
 
-export type SubmitProps = z.infer<typeof SingleTradeRouteFormSchema>;
+export type FormSubmitProps = z.infer<typeof FormSubmitSchema>;
+
+const FormResponseSchema = z.object({
+  commodityDto: ZodCommodityNameApiConst,
+  buyFromStationDto: ZodStationDtoApiConst,
+  buyPrice: z.number(),
+  stock: z.number(),
+  sellToStationDto: ZodStationDtoApiConst,
+  sellPrice: z.number(),
+  demand: z.number(),
+  profit: z.number(),
+  routeDistance: z.number(),
+});
+
+export type FormResponseProps = z.infer<typeof FormResponseSchema>;

--- a/app/_lib/api-calls.tsx
+++ b/app/_lib/api-calls.tsx
@@ -1,6 +1,6 @@
 /* eslint-disable no-console */
 // Purpose: API calls to the backend - name ending with Server are used in page.tsx, name ending with Client are used in page.client.tsx
-import useSWR from 'swr';
+import useSWR, { KeyedMutator } from 'swr';
 
 const now = new Date().toISOString();
 
@@ -67,17 +67,26 @@ const useGetMockSubmitFormClient = (queryString: string) => {
   };
 };
 
+interface SWR {
+  error: any | undefined;
+  isLoading: boolean;
+  mutate: KeyedMutator<any>;
+}
+
+type CustomResponse<T> = T & SWR;
+
 // typical request fetching data from staging URL
-const useGetData = (queryString: string) => {
-  const { data, error, isLoading, mutate } = useSWR(
-    `${process.env.NEXT_PUBLIC_STAGING_API_URL}/api/v1/${queryString}`,
-    fetcher,
-    {
-      shouldRetryOnError: false,
-      revalidateOnFocus: false,
-      revalidateOnMount: false,
-    },
-  );
+const useGetData = <T,>(queryString: string) => {
+  const { data, error, isLoading, mutate }: CustomResponse<{ data: T }> =
+    useSWR(
+      `${process.env.NEXT_PUBLIC_STAGING_API_URL}/api/v1/${queryString}`,
+      fetcher,
+      {
+        shouldRetryOnError: false,
+        revalidateOnFocus: false,
+        revalidateOnMount: false,
+      },
+    );
 
   return {
     data,

--- a/app/_types/api-responses.ts
+++ b/app/_types/api-responses.ts
@@ -1,0 +1,59 @@
+export type CommodityTypeEnumApi =
+  | 'CHEMICALS'
+  | 'CONSUMER_ITEMS'
+  | 'LEGAL_DRUGS'
+  | 'FOODS'
+  | 'INDUSTRIAL_MATERIALS'
+  | 'MACHINERY'
+  | 'MEDICINES'
+  | 'METALS'
+  | 'MINERALS'
+  | 'SALVAGE'
+  | 'SLAVES'
+  | 'TECHNOLOGY'
+  | 'TEXTILES'
+  | 'WASTE'
+  | 'WEAPONS';
+
+export type LandingPadEnumApi = 'SMALL' | 'MEDIUM' | 'LARGE';
+
+export interface CommodityDtoApi {
+  commodityName: string;
+  displayName: string;
+  type: CommodityTypeEnumApi;
+  isRare: boolean;
+}
+
+export interface SystemDtoApi {
+  eliteId: number;
+  name: string;
+  coordinates: {
+    x: number;
+    y: number;
+    z: number;
+  };
+}
+
+export interface StationDtoApi {
+  name: string;
+  arrivalDistance: number;
+  system: SystemDtoApi;
+  marketId: number;
+  planetary: boolean;
+  requireOdyssey: boolean;
+  fleetCarrier: boolean;
+  maxLandingPadSize: LandingPadEnumApi;
+  marketUpdateAt: string;
+}
+
+export interface SingleTradeAPIResponse {
+  commodityDto: CommodityDtoApi;
+  buyFromStationDto: StationDtoApi;
+  buyPrice: number;
+  stock: number;
+  sellToStationDto: StationDtoApi;
+  sellPrice: number;
+  demand: number;
+  profit: number;
+  routeDistance: number;
+}

--- a/app/_types/index.ts
+++ b/app/_types/index.ts
@@ -5,3 +5,25 @@ export type {
 } from './commodity';
 export type { IPost } from './post';
 export type { ISystem, IStation } from './celestial_objects';
+export type {
+  ZodCommodityNameApiType,
+  ZodCommodityTypeEnumApiType,
+} from './zod/zod-commodity';
+export {
+  ZodCommodityNameApiConst,
+  ZodCommodityTypeEnumApiConst,
+} from './zod/zod-commodity';
+export type { ZodLandingPadEnumType } from './zod/zod-common';
+export { ZodLandingPadEnumConst } from './zod/zod-common';
+export type { ZodSystemDtoApiType } from './zod/zod-system';
+export { ZodSystemDtoApiConst } from './zod/zod-system';
+export type { ZodStationDtoApiType } from './zod/zod-station';
+export { ZodStationDtoApiConst } from './zod/zod-station';
+export type {
+  CommodityTypeEnumApi,
+  LandingPadEnumApi,
+  CommodityDtoApi,
+  SystemDtoApi,
+  StationDtoApi,
+  SingleTradeAPIResponse,
+} from './api-responses';

--- a/app/_types/zod/zod-commodity.ts
+++ b/app/_types/zod/zod-commodity.ts
@@ -1,0 +1,32 @@
+import { z } from 'zod';
+
+export const ZodCommodityTypeEnumApiConst = z.enum([
+  'CHEMICALS',
+  'CONSUMER_ITEMS',
+  'LEGAL_DRUGS',
+  'FOODS',
+  'INDUSTRIAL_MATERIALS',
+  'MACHINERY',
+  'MEDICINES',
+  'METALS',
+  'MINERALS',
+  'SALVAGE',
+  'SLAVES',
+  'TECHNOLOGY',
+  'TEXTILES',
+  'WASTE',
+  'WEAPONS',
+]);
+
+export type ZodCommodityTypeEnumApiType = z.infer<
+  typeof ZodCommodityTypeEnumApiConst
+>;
+
+export const ZodCommodityNameApiConst = z.object({
+  commodityName: z.string(),
+  displayName: z.string(),
+  type: ZodCommodityTypeEnumApiConst,
+  isRare: z.boolean(),
+});
+
+export type ZodCommodityNameApiType = z.infer<typeof ZodCommodityNameApiConst>;

--- a/app/_types/zod/zod-common.ts
+++ b/app/_types/zod/zod-common.ts
@@ -1,0 +1,4 @@
+import { z } from 'zod';
+
+export const ZodLandingPadEnumConst = z.enum(['SMALL', 'MEDIUM', 'LARGE']);
+export type ZodLandingPadEnumType = z.infer<typeof ZodLandingPadEnumConst>;

--- a/app/_types/zod/zod-station.ts
+++ b/app/_types/zod/zod-station.ts
@@ -1,0 +1,17 @@
+import { z } from 'zod';
+import { ZodLandingPadEnumConst } from './zod-common';
+import { ZodSystemDtoApiConst } from './zod-system';
+
+export const ZodStationDtoApiConst = z.object({
+  name: z.string(),
+  arrivalDistance: z.number(),
+  system: ZodSystemDtoApiConst,
+  marketId: z.number(),
+  planetary: z.boolean(),
+  requireOdyssey: z.boolean(),
+  fleetCarrier: z.boolean(),
+  maxLandingPadSize: ZodLandingPadEnumConst,
+  marketUpdateAt: z.string(),
+});
+
+export type ZodStationDtoApiType = z.infer<typeof ZodStationDtoApiConst>;

--- a/app/_types/zod/zod-system.ts
+++ b/app/_types/zod/zod-system.ts
@@ -1,0 +1,13 @@
+import { z } from 'zod';
+
+export const ZodSystemDtoApiConst = z.object({
+  eliteId: z.number(),
+  name: z.string(),
+  coordinates: z.object({
+    x: z.number(),
+    y: z.number(),
+    z: z.number(),
+  }),
+});
+
+export type ZodSystemDtoApiType = z.infer<typeof ZodSystemDtoApiConst>;

--- a/app/trade/single/page.client.tsx
+++ b/app/trade/single/page.client.tsx
@@ -6,7 +6,7 @@ import Form from '@/components/trade-routes/single/Form';
 import GetColor from '@/app/_hooks/colorSelector';
 import { ICommodity } from '@/app/_types';
 import PageHeading from '@/app/_components/utility/pageHeading';
-import { SubmitProps } from '@/app/_components/trade-routes/single/Schema';
+import { FormSubmitProps } from '@/app/_components/trade-routes/single/Schema';
 import { useGetData } from '@/app/_lib/api-calls';
 
 interface IPageClientProps {
@@ -23,7 +23,7 @@ const PageClient = ({ commodities }: IPageClientProps) => {
     mutate: responseMutate,
   } = useGetData(requestUrl);
 
-  function encodeQueryString(obj: SubmitProps) {
+  function encodeQueryString(obj: FormSubmitProps) {
     const params: string[] = [];
     Object.entries(obj).forEach(([k, v]) => {
       if (typeof v === 'undefined') return;
@@ -43,7 +43,7 @@ const PageClient = ({ commodities }: IPageClientProps) => {
     return params.toString().replaceAll(',', '&');
   }
 
-  const handleSubmit = async (data: SubmitProps) => {
+  const handleSubmit = async (data: FormSubmitProps) => {
     setIsLoading(true);
 
     const queryParams = encodeQueryString(data);

--- a/app/trade/single/page.client.tsx
+++ b/app/trade/single/page.client.tsx
@@ -2,11 +2,12 @@
 
 import { useState } from 'react';
 import { Box, HStack, Flex } from '@chakra-ui/react';
-import Form, { SubmitProps } from '@/components/trade-routes/single/Form';
+import Form from '@/components/trade-routes/single/Form';
 import GetColor from '@/app/_hooks/colorSelector';
-import { SingleTradeRouteForm } from '@/app/_types/forms';
 import { ICommodity } from '@/app/_types';
 import PageHeading from '@/app/_components/utility/pageHeading';
+import { SubmitProps } from '@/app/_components/trade-routes/single/Schema';
+import { useGetData } from '@/app/_lib/api-calls';
 
 interface IPageClientProps {
   commodities: ICommodity[] | null;
@@ -14,19 +15,52 @@ interface IPageClientProps {
 
 const PageClient = ({ commodities }: IPageClientProps) => {
   const [isLoading, setIsLoading] = useState(false);
+  const [requestUrl, setRequestUrl] = useState('');
 
-  const handleSubmit = (data: SubmitProps) => {
+  const {
+    data: responseData,
+    error: responseError,
+    mutate: responseMutate,
+  } = useGetData(requestUrl);
+
+  function encodeQueryString(obj: SubmitProps) {
+    const params: string[] = [];
+    Object.entries(obj).forEach(([k, v]) => {
+      if (typeof v === 'undefined') return;
+      if (typeof v === 'object') {
+        if (!v) return;
+        if (k.includes('commodity') && Array.isArray(v))
+          v.map((commodity) =>
+            params.push(`commodityDisplayNames=${commodity}`),
+          );
+        if (k.includes('sell') || k.includes('buy')) {
+          if ('label' in v) params.push(`${k}=${v.label}`);
+        }
+        return;
+      }
+      params.push(`${k}=${v}`);
+    });
+    return params.toString().replaceAll(',', '&');
+  }
+
+  const handleSubmit = async (data: SubmitProps) => {
     setIsLoading(true);
 
-    let submitData: SingleTradeRouteForm = {
-      ...data,
-    };
+    const queryParams = encodeQueryString(data);
+    const queryUrl = `trade/locate-trade/single?${queryParams}`;
+    setRequestUrl(queryUrl);
+    if (requestUrl !== '') await responseMutate();
+
+    // TODO: we'll use availableCredits with cargoCapacity to present overall profit
+    // once the response returns with profit per
+    // includeOdyssey isn't being filtered atm
+    // const includeOdyssey = data.includeOdyssey;
+    // const availableCredits = data.availableCredits;
 
     // TODO: format and submit data to backend
-    setTimeout(() => {
-      console.log('submitted ', submitData);
-      setIsLoading(false);
-    }, 2000);
+    const res = responseError ?? responseData;
+    console.log('response', res);
+    setIsLoading(false);
   };
 
   return (

--- a/app/trade/single/page.client.tsx
+++ b/app/trade/single/page.client.tsx
@@ -1,13 +1,16 @@
 'use client';
 
 import { useState } from 'react';
-import { Box, HStack, Flex } from '@chakra-ui/react';
+import { Box, HStack, Flex, Text } from '@chakra-ui/react';
 import Form from '@/components/trade-routes/single/Form';
 import GetColor from '@/app/_hooks/colorSelector';
-import { ICommodity } from '@/app/_types';
 import PageHeading from '@/app/_components/utility/pageHeading';
-import { FormSubmitProps } from '@/app/_components/trade-routes/single/Schema';
 import { useGetData } from '@/app/_lib/api-calls';
+import {
+  FormResponseProps,
+  FormSubmitProps,
+} from '@/app/_components/trade-routes/single/Schema';
+import { ICommodity } from '@/app/_types';
 
 interface IPageClientProps {
   commodities: ICommodity[] | null;
@@ -21,8 +24,9 @@ const PageClient = ({ commodities }: IPageClientProps) => {
     data: responseData,
     error: responseError,
     mutate: responseMutate,
-  } = useGetData(requestUrl);
+  } = useGetData<FormResponseProps[]>(requestUrl);
 
+  // TODO: this is messy. can it be made universal and extracted?
   function encodeQueryString(obj: FormSubmitProps) {
     const params: string[] = [];
     Object.entries(obj).forEach(([k, v]) => {
@@ -52,14 +56,11 @@ const PageClient = ({ commodities }: IPageClientProps) => {
     if (requestUrl !== '') await responseMutate();
 
     // TODO: we'll use availableCredits with cargoCapacity to present overall profit
-    // once the response returns with profit per
+    // once the response returns with profit per unit
     // includeOdyssey isn't being filtered atm
-    // const includeOdyssey = data.includeOdyssey;
-    // const availableCredits = data.availableCredits;
 
-    // TODO: format and submit data to backend
     const res = responseError ?? responseData;
-    console.log('response', res);
+    console.log("submitted! here's the response", res);
     setIsLoading(false);
   };
 
@@ -68,6 +69,12 @@ const PageClient = ({ commodities }: IPageClientProps) => {
       <HStack spacing={4}>
         <PageHeading heading="Single Trade Route Finder" />
       </HStack>
+      <Text>Find a one-way trade with your choice of filters.</Text>
+      <Text>
+        Be sure to include either a buy system, a sell system, or both. You
+        don't have to select a station if you're happy with anywhere within that
+        system.
+      </Text>
       <Box
         borderWidth="2px"
         borderRadius="9px"


### PR DESCRIPTION
In order to start wiring together a UI to present the response for the form submission in this route, there are a few tasks that needed to be accomplished. This PR focuses on the following:

1. Create necessary types and Zod schema to validate both the form submit object, as well as the form response object on success

2. Update form submit object keys (ie: rename commodityDisplayName to commodityDisplayNames) to match the backend terminology

3. Establish form default values for a few inputs such as 'maxRouteDistance' to simplify the UX

4. update the hook we use to fetch data on form submits `useGetData` to require a response data type to be passed to it