### PR TITLE
149-Fix-market-timestamp-for-trade-reponses

### DIFF
--- a/app/_components/trade-routes/single/response/desktop/BodyDesktop.tsx
+++ b/app/_components/trade-routes/single/response/desktop/BodyDesktop.tsx
@@ -151,7 +151,7 @@ const ResponseBody = ({
                   </Text>
                   <Text color={selectTextColorAccent}>
                     {calculateTimeDifference(
-                      data.buyFromStationDto.marketUpdateAt,
+                      data.buyFromStationDto.marketUpdatedAt,
                     )}
                   </Text>
                 </HStack>
@@ -209,7 +209,7 @@ const ResponseBody = ({
                 </Text>
                 <Text color={selectTextColorAccent}>
                   {calculateTimeDifference(
-                    data.sellToStationDto.marketUpdateAt,
+                    data.sellToStationDto.marketUpdatedAt,
                   )}
                 </Text>
               </HStack>

--- a/app/_components/trade-routes/single/response/mobile/BodyMobile.tsx
+++ b/app/_components/trade-routes/single/response/mobile/BodyMobile.tsx
@@ -195,7 +195,7 @@ const ResponseBody = ({
                 </Text>
                 <Text color={selectTextColorAccent} fontSize="xs">
                   {calculateTimeDifference(
-                    data.buyFromStationDto.marketUpdateAt,
+                    data.buyFromStationDto.marketUpdatedAt,
                   )}
                 </Text>
               </HStack>
@@ -275,7 +275,7 @@ const ResponseBody = ({
                 </Text>
                 <Text color={selectTextColorAccent} fontSize="xs">
                   {calculateTimeDifference(
-                    data.sellToStationDto.marketUpdateAt,
+                    data.sellToStationDto.marketUpdatedAt,
                   )}
                 </Text>
               </HStack>

--- a/app/_components/trade-routes/single/response/response.test.tsx
+++ b/app/_components/trade-routes/single/response/response.test.tsx
@@ -56,7 +56,7 @@ const mockedBuyStation: ZodStationDtoApiType = {
   requireOdyssey: false,
   fleetCarrier: false,
   maxLandingPadSize: 'LARGE',
-  marketUpdateAt: now,
+  marketUpdatedAt: now,
 };
 
 const mockedSellStation: ZodStationDtoApiType = {
@@ -68,7 +68,7 @@ const mockedSellStation: ZodStationDtoApiType = {
   requireOdyssey: false,
   fleetCarrier: false,
   maxLandingPadSize: 'LARGE',
-  marketUpdateAt: now,
+  marketUpdatedAt: now,
 };
 
 const mockedBuyStation2: ZodStationDtoApiType = {
@@ -80,7 +80,7 @@ const mockedBuyStation2: ZodStationDtoApiType = {
   requireOdyssey: false,
   fleetCarrier: false,
   maxLandingPadSize: 'LARGE',
-  marketUpdateAt: now,
+  marketUpdatedAt: now,
 };
 
 const mockedResults: FormResponseProps[] = [

--- a/app/_types/api-responses.ts
+++ b/app/_types/api-responses.ts
@@ -43,7 +43,7 @@ export interface StationDtoApi {
   requireOdyssey: boolean;
   fleetCarrier: boolean;
   maxLandingPadSize: LandingPadEnumApi;
-  marketUpdateAt: string;
+  marketUpdatedAt: string;
 }
 
 export interface SingleTradeAPIResponse {

--- a/app/_types/zod/zod-station.ts
+++ b/app/_types/zod/zod-station.ts
@@ -11,7 +11,7 @@ export const ZodStationDtoApiConst = z.object({
   requireOdyssey: z.boolean(),
   fleetCarrier: z.boolean(),
   maxLandingPadSize: ZodLandingPadEnumConst,
-  marketUpdateAt: z.string(),
+  marketUpdatedAt: z.string(),
 });
 
 export type ZodStationDtoApiType = z.infer<typeof ZodStationDtoApiConst>;


### PR DESCRIPTION
updated various marketUpdateAt fields to be marketUpdatedAt to align with API format.

Converts NaN -> correct date formatting for trade response data